### PR TITLE
docs(trainer): fix gradient clipping entry

### DIFF
--- a/docs/Trainer/Training Loop.md
+++ b/docs/Trainer/Training Loop.md
@@ -28,14 +28,17 @@ trainer = Trainer(enable_early_stop=True)
 ```
 
 ---
-#### Gradient Clipping 
-Use this to turn off early stopping and run training to the [max_epoch](#force-training-for-min-or-max-epochs)
+#### Gradient Clipping
+Gradient clipping may be enabled to avoid exploding gradients.
+Specifically, this will [clip the gradient norm computed over all model parameters *together*](https://pytorch.org/docs/stable/nn.html#torch.nn.utils.clip_grad_norm_).
+
 ``` {.python}
 # DEFAULT (ie: don't clip)
 trainer = Trainer(gradient_clip=0)
+
+# clip gradients with norm above 0.5
+trainer = Trainer(gradient_clip=0.5)
 ```
-
-
 
 ---
 #### Inspect gradient norms


### PR DESCRIPTION
I've just been reading through the documentation of this very promising library!

I found a [copy-paste error](https://williamfalcon.github.io/pytorch-lightning/Trainer/Training%20Loop/#gradient-clipping) in the training loop part of the docs. I'm sure the documentation is going to get a lot more attention once the codebase gets a bit more mature, but I thought I would give a little help! This PR
- replaces the copy and paste error
- writes a very brief description of GC
- adds link to pytorch docs for specific GC implementation
- adds an example configuration **(please note I haven't tried it out yet**, but for a quick grok it looks it just calls the usual pytorch api so should be fine).

Looking forward to trying the project out!