### PR TITLE
docs: enable syntax highlight

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,3 +8,8 @@ site_description: 'Documentation for PyTorch LightningModule, the researcher ver
 
 dev_addr: '0.0.0.0:8000'
 #google_analytics: ['UA-aasd', 'sitename']
+
+markdown_extensions:
+  - codehilite:
+      guess_lang: false
+      linenums: true


### PR DESCRIPTION
Hi, thought it'd be better with highlight.
More attempts with mkdocs-material extentions can be found [here](https://github.com/OI-wiki/OI-wiki/blob/master/mkdocs.yml#L392).

upd: Oh btw, it would require `pymdown-extensions` installed, I'm new here and not sure where to add this.