### PR TITLE
use val_percent_check in validation step

### DIFF
--- a/pytorch_lightning/models/trainer.py
+++ b/pytorch_lightning/models/trainer.py
@@ -1094,9 +1094,9 @@ If you want each process to load the full dataset, ignore this warning.
                 model = self.__get_model()
                 model.on_pre_performance_check()
 
-            # use full val set on end of epoch
+            # use val_percent_check set on end of epoch
             # use a small portion otherwise
-            max_batches = None if not self.fast_dev_run else 1
+            max_batches = self.nb_val_batches if not self.fast_dev_run else 1
             for ds_i, dataloader in enumerate(self.val_dataloader):
                 val_out_metrics = self.validate(self.model, dataloader, max_batches, ds_i)
                 self.__add_tqdm_metrics(val_out_metrics)


### PR DESCRIPTION
Looks like `val_percent_check` only used when calculating `self.total_batches` for progressbar limit, so when you set `val_percent_check=0.01` and run `trainer.fit(model)` full validation set will be used at the end of train epoch and tqdm progress bar will be corrupted (overflow):
```112it [00:22,  7.21it/s, batch_nb=45, dice=0.0788, epoch=1, gpu=0, tng_loss=0.528, v_nb=33]  ```

This patch fixes it, and only `val_percent_check` percent of validation set used in validation