### PR TITLE
Added pl.property to decorators.

### DIFF
--- a/pytorch_lightning/root_module/decorators.py
+++ b/pytorch_lightning/root_module/decorators.py
@@ -1,3 +1,21 @@
+from builtins import property as _property # Prevents recursive call.
+
+def property(fn):
+    # Warning: This shadows the usual property, so @property use
+    # below this definition is invalid unless the safe variant is needed.
+    """
+    Makes properties in subclasses of nn.Module (e.g. LightningModule)
+     return more informative AttributeError exceptions.
+    :param fn:
+    :return:
+    """
+    @_property
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except AttributeError as e:
+            raise RuntimeError('An AttributeError was encountered: ' + str(e)) from e
+    return wrapper
 
 def data_loader(fn):
     """


### PR DESCRIPTION
A solution for https://github.com/williamFalcon/pytorch-lightning/issues/142.
Then users can use @pl.property on their LightningModules and be safe.