### PR TITLE
Guard against AttributeError in dataloaders.

### DIFF
--- a/pytorch_lightning/root_module/decorators.py
+++ b/pytorch_lightning/root_module/decorators.py
@@ -10,8 +10,15 @@ def data_loader(fn):
 
     @property
     def _data_loader(self):
-        if not hasattr(self, attr_name):
-            setattr(self, attr_name, fn(self))
-        return getattr(self, attr_name)
+        try:
+            value = getattr(self, attr_name)
+        except AttributeError:
+            try:
+                value = fn(self)  # Lazy evaluation, done only once.
+            except AttributeError as e:
+                # Guard against AttributeError suppression. (Issue #142)
+                raise RuntimeError('An AttributeError was encountered: ' + str(e)) from e
+            setattr(self, attr_name, value)  # Memoize evaluation.
+        return value
 
     return _data_loader


### PR DESCRIPTION
A solution for https://github.com/williamFalcon/pytorch-lightning/issues/142.
Since `hasattr` "[calls getattr(object, name) to see whether it raises an AttributeError or not](https://docs.python.org/3/library/functions.html#hasattr)", I replaced it with a single call to `getattr`. See also https://hynek.me/articles/hasattr/ for more in-depth info.