### PR TITLE
Fix incorrect warning for DistributedSampler.

### DIFF
--- a/pytorch_lightning/models/trainer.py
+++ b/pytorch_lightning/models/trainer.py
@@ -516,11 +516,11 @@ class Trainer(TrainerIO):
             """
             warnings.warn(msg)
 
-        if self.use_ddp and self.val_dataloader is not None:
+         if self.use_ddp and self.val_dataloader is not None:
             for dataloader in self.val_dataloader:
-                if not isinstance(dataloader, DistributedSampler):
+                if not isinstance(dataloader.sampler, DistributedSampler):
                     msg = """
-                    Your val_dataloader(s) are not all DistributedSamplers.
+                    Your val_dataloader(s) don't use DistributedSampler.
                     You're using multiple gpus and multiple nodes without using a DistributedSampler
                     to assign a subset of your data to each process. To silence this warning, pass a
                     DistributedSampler to your DataLoader.
@@ -541,9 +541,9 @@ class Trainer(TrainerIO):
 
         if self.use_ddp and self.test_dataloader is not None:
             for dataloader in self.test_dataloader:
-                if not isinstance(dataloader, DistributedSampler):
+                if not isinstance(dataloader.sampler, DistributedSampler):
                     msg = """
-                    Your test_dataloader(s) are not all DistributedSamplers.
+                    Your test_dataloader(s) don't use DistributedSampler.
                     You're using multiple gpus and multiple nodes without using a DistributedSampler
                     to assign a subset of your data to each process. To silence this warning, pass a
                     DistributedSampler to your DataLoader.
@@ -556,7 +556,7 @@ class Trainer(TrainerIO):
                     dataset = myDataset()
                     dist_sampler = torch.utils.data.distributed.DistributedSampler(dataset)
                     dataloader = Dataloader(dataset, sampler=dist_sampler)
-
+                    
                     If you want each process to load the full dataset, ignore this warning.
                     """
                     warnings.warn(msg)

--- a/pytorch_lightning/models/trainer.py
+++ b/pytorch_lightning/models/trainer.py
@@ -516,7 +516,7 @@ class Trainer(TrainerIO):
             """
             warnings.warn(msg)
 
-         if self.use_ddp and self.val_dataloader is not None:
+        if self.use_ddp and self.val_dataloader is not None:
             for dataloader in self.val_dataloader:
                 if not isinstance(dataloader.sampler, DistributedSampler):
                     msg = """


### PR DESCRIPTION
Check whether `dataloader.sampler` is an instance of DistributedSampler instead of the `dataloader` itself.