### PR TITLE
Nvidia flags for multi-node single gpu

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -183,6 +183,9 @@ class Trainer(TrainerIO):
         self.node_rank = 0
         self.__configure_slurm_ddp()
 
+        # nvidia setup
+        self.__set_nvidia_flags()
+
         # can't init progress bar here because starting a new process
         # means the prog_bar won't survive pickling
         self.show_progress_bar = show_progress_bar

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -708,7 +708,10 @@ class Trainer(TrainerIO):
         # allow for lr schedulers as well
         self.optimizers, self.lr_schedulers = self.init_optimizers(model.configure_optimizers())
 
-        model.cuda(self.data_parallel_device_ids[0])
+        root_gpu = 0
+        if type(self.data_parallel_device_ids) is list:
+            root_gpu = self.data_parallel_device_ids[0]
+        model.cuda(root_gpu)
 
         # check for this bug (amp + dp + !01 doesn't work)
         # https://github.com/NVIDIA/apex/issues/227

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -259,11 +259,6 @@ class Trainer(TrainerIO):
             else:
                 raise Exception('gpus has to be a string or list of ids')
 
-            # set the correct cuda visible devices (using pci order)
-            os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-            os.environ["CUDA_VISIBLE_DEVICES"] = ','.join([str(x) for x in gpus])
-            print('VISIBLE GPUS: %r' % os.environ["CUDA_VISIBLE_DEVICES"])
-
         return gpus
 
     def __set_distributed_mode(self, distributed_backend, nb_gpu_nodes):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -91,7 +91,7 @@ class Trainer(TrainerIO):
         :param gradient_clip: int. 0 means don't clip.
         :param process_position: shown in the tqdm bar
         :param nb_gpu_nodes: number of GPU nodes
-        :param gpus: list or string of gpu ids [0, 1] or '0,1'
+        :param gpus: int. (ie: 2 gpus) OR list to specify which GPUs [0, 1] or '0,1'
         :param log_gpu_memory: Bool. If true, adds memory logs
         :param show_progress_bar: Bool. If true shows tqdm bar
         :param overfit_pct: float. uses this much of all datasets
@@ -168,7 +168,7 @@ class Trainer(TrainerIO):
         # accumulated grads
         self.__configure_accumulated_gradients(accumulate_grad_batches)
 
-        # allow string and gpu list
+        # allow int, string and gpu list
         self.data_parallel_device_ids = self.__parse_gpu_ids(gpus)
 
         # distributed backend choice

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -221,7 +221,8 @@ class Trainer(TrainerIO):
             self.weights_save_path = self.checkpoint_callback.filepath
 
         # if weights_save_path is still none here, set to current workingdir
-        self.weights_save_path = os.getcwd()
+        if self.weights_save_path is None:
+            self.weights_save_path = os.getcwd()
 
     def __init_amp(self, use_amp):
         self.use_amp = use_amp and APEX_AVAILABLE

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -340,9 +340,10 @@ class Trainer(TrainerIO):
 
         # when slurm is managing the task it sets the visible devices
         if not is_slurm_managing_tasks:
-            if type(data_parallel_device_ids) is int and data_parallel_device_ids > 0:
-                id_str = ','.join(list(range(data_parallel_device_ids)))
-                os.environ["CUDA_VISIBLE_DEVICES"] = id_str
+            if type(data_parallel_device_ids) is int:
+                if data_parallel_device_ids > 0:
+                    id_str = ','.join(list(range(data_parallel_device_ids)))
+                    os.environ["CUDA_VISIBLE_DEVICES"] = id_str
             else:
                 gpu_str = ','.join([str(x) for x in data_parallel_device_ids])
                 os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -184,7 +184,7 @@ class Trainer(TrainerIO):
         self.__configure_slurm_ddp(self.data_parallel_device_ids, nb_gpu_nodes)
 
         # nvidia setup
-        self.__set_nvidia_flags()
+        self.__set_nvidia_flags(self.is_slurm_managing_tasks)
 
         # can't init progress bar here because starting a new process
         # means the prog_bar won't survive pickling
@@ -303,12 +303,12 @@ class Trainer(TrainerIO):
                 # likely not on slurm, so set the slurm managed flag to false
                 self.is_slurm_managing_tasks = False
 
-    def __set_nvidia_flags(self):
+    def __set_nvidia_flags(self, is_slurm_managing_tasks):
         # set the correct cuda visible devices (using pci order)
         os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
 
         # when slurm is managing the task it sets the visible devices
-        if not self.is_slurm_managing_tasks:
+        if not is_slurm_managing_tasks:
             gpu_str = ','.join([str(x) for x in self.data_parallel_device_ids])
             os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1091,7 +1091,9 @@ class Trainer(TrainerIO):
         elif self.use_dp:
             output = self.model(*args)
         elif self.single_gpu:
-            gpu_id = self.data_parallel_device_ids[0]
+            gpu_id = 0
+            if type(self.data_parallel_device_ids) is list:
+                gpu_id = self.data_parallel_device_ids[0]
             data_batch = self.transfer_batch_to_gpu(data_batch, gpu_id)
             args[0] = data_batch
             output = self.model.training_step(*args)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -291,6 +291,8 @@ class Trainer(TrainerIO):
         print('gpu available: {}, used: {}'.format(torch.cuda.is_available(), self.on_gpu))
 
     def __configure_slurm_ddp(self, gpu_ids, nb_gpu_nodes):
+        self.is_slurm_managing_tasks = False
+
         # extract SLURM flag vars
         # whenever we have the correct number of tasks, we let slurm manage processes
         # otherwise we launch the required number of processes

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -458,8 +458,10 @@ class Trainer(TrainerIO):
         # CPU, single GPU
         if self.single_gpu:
             # for single GPU put inputs on gpu manually
-            gpu_id = self.data_parallel_device_ids[0]
-            data_batch = self.transfer_batch_to_gpu(data_batch, gpu_id)
+            root_gpu = 0
+            if type(self.data_parallel_device_ids) is list:
+                root_gpu = self.data_parallel_device_ids[0]
+            data_batch = self.transfer_batch_to_gpu(data_batch, root_gpu)
             args[0] = data_batch
 
         if test:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -181,7 +181,7 @@ class Trainer(TrainerIO):
         self.proc_rank = 0
         self.world_size = 1
         self.node_rank = 0
-        self.__configure_slurm_ddp()
+        self.__configure_slurm_ddp(self.data_parallel_device_ids, nb_gpu_nodes)
 
         # nvidia setup
         self.__set_nvidia_flags()
@@ -289,12 +289,12 @@ class Trainer(TrainerIO):
 
         print('gpu available: {}, used: {}'.format(torch.cuda.is_available(), self.on_gpu))
 
-    def __configure_slurm_ddp(self):
+    def __configure_slurm_ddp(self, gpu_ids, nb_gpu_nodes):
         # extract SLURM flag vars
         # whenever we have the correct number of tasks, we let slurm manage processes
         # otherwise we launch the required number of processes
         if self.use_ddp:
-            self.nb_requested_gpus = len(self.data_parallel_device_ids) * self.nb_gpu_nodes
+            self.nb_requested_gpus = len(gpu_ids) * nb_gpu_nodes
             self.nb_slurm_tasks = 0
             try:
                 self.nb_slurm_tasks = int(os.environ['SLURM_NTASKS'])

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -341,9 +341,8 @@ class Trainer(TrainerIO):
         # when slurm is managing the task it sets the visible devices
         if not is_slurm_managing_tasks:
             if type(data_parallel_device_ids) is int:
-                if data_parallel_device_ids > 0:
-                    id_str = ','.join(list(range(data_parallel_device_ids)))
-                    os.environ["CUDA_VISIBLE_DEVICES"] = id_str
+                id_str = ','.join(str(x) for x in list(range(data_parallel_device_ids)))
+                os.environ["CUDA_VISIBLE_DEVICES"] = id_str
             else:
                 gpu_str = ','.join([str(x) for x in data_parallel_device_ids])
                 os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -305,6 +305,17 @@ class Trainer(TrainerIO):
                 # likely not on slurm, so set the slurm managed flag to false
                 self.is_slurm_managing_tasks = False
 
+    def __set_nvidia_flags(self):
+        # set the correct cuda visible devices (using pci order)
+        os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
+
+        # when slurm is managing the task it sets the visible devices
+        if not self.is_slurm_managing_tasks:
+            gpu_str = ','.join([str(x) for x in self.data_parallel_device_ids])
+            os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
+
+        print(f'VISIBLE GPUS: {os.environ["CUDA_VISIBLE_DEVICES"]}')
+
     @property
     def data_parallel(self):
         return self.use_dp or self.use_ddp

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -642,7 +642,8 @@ class Trainer(TrainerIO):
                 If you're not using SLURM, ignore this message!
                 """
                 warnings.warn(msg)
-                mp.spawn(self.ddp_train, nprocs=len(self.data_parallel_device_ids), args=(model, ))
+                nb_gpus = self.__nb_gpus(self.data_parallel_device_ids)
+                mp.spawn(self.ddp_train, nprocs=nb_gpus, args=(model, ))
 
         # 1 gpu or dp option triggers training using DP module
         # easier to avoid NCCL issues

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -340,8 +340,12 @@ class Trainer(TrainerIO):
 
         # when slurm is managing the task it sets the visible devices
         if not is_slurm_managing_tasks:
-            gpu_str = ','.join([str(x) for x in data_parallel_device_ids])
-            os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
+            if type(data_parallel_device_ids) is int:
+                id_str = ','.join(list(range(data_parallel_device_ids)))
+                os.environ["CUDA_VISIBLE_DEVICES"] = id_str
+            else:
+                gpu_str = ','.join([str(x) for x in data_parallel_device_ids])
+                os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
 
         print(f'VISIBLE GPUS: {os.environ["CUDA_VISIBLE_DEVICES"]}')
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -340,7 +340,7 @@ class Trainer(TrainerIO):
 
         # when slurm is managing the task it sets the visible devices
         if not is_slurm_managing_tasks:
-            if type(data_parallel_device_ids) is int:
+            if type(data_parallel_device_ids) is int and data_parallel_device_ids > 0:
                 id_str = ','.join(list(range(data_parallel_device_ids)))
                 os.environ["CUDA_VISIBLE_DEVICES"] = id_str
             else:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -691,7 +691,10 @@ class Trainer(TrainerIO):
         # allow for lr schedulers as well
         self.optimizers, self.lr_schedulers = self.init_optimizers(model.configure_optimizers())
 
-        model.cuda(self.data_parallel_device_ids[0])
+        root_gpu = 0
+        if type(self.data_parallel_device_ids) is list:
+            root_gpu = self.data_parallel_device_ids[0]
+        model.cuda(root_gpu)
 
         if self.use_amp:
             # An example

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1024,6 +1024,27 @@ def test_single_gpu_model():
 
     run_gpu_model_test(trainer_options, model, hparams)
 
+def test_multi_gpu_none_backend():
+    """
+    Make sure when using multiple GPUs the user can't use
+    distributed_backend = None
+    :return:
+    """
+    if not can_run_gpu_test():
+        return
+
+    model, hparams = get_model()
+    trainer_options = dict(
+        show_progress_bar=False,
+        max_nb_epochs=1,
+        train_percent_check=0.1,
+        val_percent_check=0.1,
+        gpus='-1'
+    )
+
+    with pytest.raises(MisconfigurationException):
+        run_gpu_model_test(trainer_options, model, hparams)
+
 
 def test_multi_gpu_model_dp():
     """
@@ -1036,6 +1057,7 @@ def test_multi_gpu_model_dp():
     model, hparams = get_model()
     trainer_options = dict(
         show_progress_bar=False,
+        distributed_backend='dp',
         max_nb_epochs=1,
         train_percent_check=0.1,
         val_percent_check=0.1,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -585,7 +585,7 @@ def test_amp_single_gpu():
     trainer_options = dict(
         show_progress_bar=True,
         max_nb_epochs=1,
-        gpus=[0],
+        gpus=1,
         distributed_backend='dp',
         use_amp=True
     )
@@ -675,7 +675,7 @@ def test_amp_gpu_ddp():
     trainer_options = dict(
         show_progress_bar=True,
         max_nb_epochs=1,
-        gpus=[0, 1],
+        gpus=2,
         distributed_backend='ddp',
         use_amp=True
     )
@@ -1019,7 +1019,7 @@ def test_single_gpu_model():
         max_nb_epochs=1,
         train_percent_check=0.1,
         val_percent_check=0.1,
-        gpus=[0]
+        gpus=1
     )
 
     run_gpu_model_test(trainer_options, model, hparams)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1024,6 +1024,7 @@ def test_single_gpu_model():
 
     run_gpu_model_test(trainer_options, model, hparams)
 
+
 def test_multi_gpu_none_backend():
     """
     Make sure when using multiple GPUs the user can't use


### PR DESCRIPTION
## What does this PR do?
Changes gpu API to take integers as well (now as the preferred default).
ie:
```python
trainer = Trainer(gpus=[0, 1])

# becomes
trainer = Trainer(gpus=2)
```  

Also removes lightning managing visible devices when running on SLURM cluster.
Still supports the old syntax for people who want fine-grain control over which GPUs (ie: not in cluster)