### PR TITLE
disable auto gpu loading when restoring weights to avoid OOM

### DIFF
--- a/pytorch_lightning/root_module/root_module.py
+++ b/pytorch_lightning/root_module/root_module.py
@@ -130,17 +130,16 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
         return None
 
     @classmethod
-    def load_from_metrics(cls, weights_path, tags_csv, on_gpu):
+    def load_from_metrics(cls, weights_path, tags_csv):
         """
         Primary way of loading model from csv weights path
         :param weights_path:
         :param tags_csv:
-        :param on_gpu:
         :param map_location: dic for mapping storage {'cuda:1':'cuda:0'}
         :return:
         """
         hparams = load_hparams_from_tags_csv(tags_csv)
-        hparams.__setattr__('on_gpu', False)	
+        hparams.__setattr__('on_gpu', False)
 
         # load on CPU only to avoid OOM issues
         # then its up to user to put back on GPUs

--- a/pytorch_lightning/root_module/root_module.py
+++ b/pytorch_lightning/root_module/root_module.py
@@ -140,6 +140,7 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
         :return:
         """
         hparams = load_hparams_from_tags_csv(tags_csv)
+        hparams.__setattr__('on_gpu', False)	
 
         # load on CPU only to avoid OOM issues
         # then its up to user to put back on GPUs

--- a/pytorch_lightning/root_module/root_module.py
+++ b/pytorch_lightning/root_module/root_module.py
@@ -140,7 +140,6 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
         :return:
         """
         hparams = load_hparams_from_tags_csv(tags_csv)
-        hparams.__setattr__('on_gpu', on_gpu)
 
         # load on CPU only to avoid OOM issues
         # then its up to user to put back on GPUs

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -568,7 +568,7 @@ def test_no_val_module():
     tags_path = exp.get_data_path(exp.name, exp.version)
     tags_path = os.path.join(tags_path, 'meta_tags.csv')
     model_2 = LightningTestModel.load_from_metrics(weights_path=new_weights_path,
-                                                   tags_csv=tags_path, on_gpu=False)
+                                                   tags_csv=tags_path)
     model_2.eval()
 
     # make prediction

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1415,8 +1415,8 @@ def load_model(exp, save_dir, on_gpu, module_class=LightningTemplateModel):
     weights_dir = os.path.join(save_dir, checkpoints[0])
 
     trained_model = module_class.load_from_metrics(weights_path=weights_dir,
-                                                   tags_csv=tags_path,
-                                                   on_gpu=on_gpu)
+                                                   tags_csv=tags_path
+                                                   )
 
     assert trained_model is not None, 'loading model failed'
 


### PR DESCRIPTION
Lightning always saves non dp, ddp weights... this way the user isn't tied into gpus when restoring