### PR TITLE
WIP: Moved grad_norm tracking code to __run_tng_batch 

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1227,7 +1227,7 @@ class Trainer(TrainerIO):
             if (self.batch_nb + 1) % self.accumulate_grad_batches == 0:
 
                 # track gradient norms when requested
-                if batch_nb % self.row_log_interval == 0 or early_stop_epoch:
+                if batch_nb % self.row_log_interval == 0:
                     if self.track_grad_norm > 0:
                         model = self.__get_model()
                         grad_norm_dic = model.grad_norm(self.track_grad_norm)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1175,7 +1175,7 @@ class Trainer(TrainerIO):
 
     def __run_training_batch(self, batch, batch_nb):
         # track grad norms
-        grad_norm_dic = None
+        grad_norm_dic = {}
 
         if batch is None:
             return 0, grad_norm_dic

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1023,12 +1023,6 @@ class Trainer(TrainerIO):
                     mem_map = get_gpu_memory_map()
                     metrics.update(mem_map)
 
-                # add norms
-                if self.track_grad_norm > 0:
-                    model = self.__get_model()
-                    grad_norm_dic = model.grad_norm(self.track_grad_norm)
-                    metrics.update(grad_norm_dic)
-
                 if self.__is_function_implemented('on_tng_metrics'):
                     model.on_tng_metrics(metrics)
 
@@ -1229,7 +1223,11 @@ class Trainer(TrainerIO):
             if (self.batch_nb + 1) % self.accumulate_grad_batches == 0:
                 # clip gradients
                 self.__clip_gradients()
-
+                # add norms
+                if self.track_grad_norm > 0:
+                    model = self.__get_model()
+                    grad_norm_dic = model.grad_norm(self.track_grad_norm)
+                    self.__add_tqdm_metrics(grad_norm_dic)
                 # calls .step(), .zero_grad()
                 # override function to modify this behavior
                 model = self.__get_model()

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1225,13 +1225,15 @@ class Trainer(TrainerIO):
 
             # gradient update with accumulated gradients
             if (self.batch_nb + 1) % self.accumulate_grad_batches == 0:
-                # clip gradients
-                self.__clip_gradients()
-                # add norms
+                # track gradient norms when requested
                 if self.track_grad_norm > 0:
                     model = self.__get_model()
                     grad_norm_dic = model.grad_norm(self.track_grad_norm)
                     self.__add_tqdm_metrics(grad_norm_dic)
+
+                # clip gradients
+                self.__clip_gradients()
+
                 # calls .step(), .zero_grad()
                 # override function to modify this behavior
                 model = self.__get_model()


### PR DESCRIPTION
## What does this PR do?
Fixes #272 

I had to change `metrics.update(grad_norm_dic)` to `self.__add_tqdm_metrics(grad_norm_dic)` to be able to save the metrics. However, with the current implementation all of the `grad_norm` metrics end up in the tqdm progress bar, which, I assume,  is not what we want. Since I'm new to the code, the specifics of the `tqdm_metrics` attribute are not completely clear to me yet. So, I'd like to hear your thought about how to tackle this. Some ideas:
- We could spit up metrics to be logged to disk and metrics to be shown in tqdm
- Maybe we could move all metrics code (https://github.com/williamFalcon/pytorch-lightning/blob/master/pytorch_lightning/trainer/trainer.py#L1011-L1038) into the new location?
- We could create a new parameter to the function and write metrics to that.
- Others? I may miss something obvious of course.