### PR TITLE
Better error message if no loss was returned from model.training_step()

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1158,6 +1158,10 @@ class Trainer(TrainerIO):
         except Exception:
             if type(output) is torch.Tensor:
                 loss = output
+            else:
+                raise RuntimeError(
+                    'No `loss` value in the dictionary returned from `model.training_step()`.'
+                )
 
         # when using dp need to reduce the loss
         if self.use_dp:


### PR DESCRIPTION
## What does this PR do?
Improves an error message 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.   

## Did you have fun?
Make sure you had fun coding 🙃
