### PR TITLE
Add option to explicitly preprocess a batch before training

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -531,6 +531,11 @@ class Trainer(TrainerIO):
                 if batch_idx >= max_batches:
                     break
 
+                # preprocess batch
+                if self.__is_function_implemented('preprocess_batch'):
+                    model = self.__get_model()
+                    batch = model.preprocess_batch(batch)
+
                 # -----------------
                 # RUN EVALUATION STEP
                 # -----------------
@@ -988,6 +993,11 @@ class Trainer(TrainerIO):
             met_batch_limit = batch_nb > self.nb_training_batches
             if met_batch_limit:
                 break
+
+            # preprocess batch
+            if self.__is_function_implemented('preprocess_batch'):
+                model = self.__get_model()
+                batch = model.preprocess_batch(batch)
 
             # ---------------
             # RUN TRAIN STEP


### PR DESCRIPTION
## What does this PR do?
This PR adds a feature that enables explicit preprocessing of a batch. This is useful if the same preprocessing is necessary for `training_step()` and `validation_step()`. This will be further helpful for #293, when the preprocessing only needs to be done once per batch and for every tbptt step the preprocessed input can be reused.

Code example:
```py
def preprocess_batch(self, batch):
    batch.input_seq, lengths = nn.utils.rnn.pad_packed_sequence(
         batch.input_seq, batch_first=True
    )
    return batch

```

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.   

## Did you have fun?
Make sure you had fun coding 🙃
