### PR TITLE
Load mem

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Lightning sets up all the boilerplate state-of-the-art training for you so you c
 - [Lightning features](https://github.com/williamFalcon/pytorch-lightning#lightning-automates-all-of-the-following-each-is-also-configurable)    
 - [Examples](https://github.com/williamFalcon/pytorch-lightning#examples)    
 - [Tutorials](https://github.com/williamFalcon/pytorch-lightning#tutorials)
-- [Contributing](https://github.com/williamFalcon/pytorch-lightning/blob/master/CONTRIBUTING.md)    
+- [Contributing](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)
 - [Bleeding edge install](https://github.com/williamFalcon/pytorch-lightning#bleeding-edge)   
 - [Lightning Design Principles](https://github.com/williamFalcon/pytorch-lightning#lightning-design-principles)   
 - [Asking for help](https://github.com/williamFalcon/pytorch-lightning#asking-for-help)

--- a/docs/Trainer/debugging.md
+++ b/docs/Trainer/debugging.md
@@ -38,6 +38,14 @@ trainer = Trainer(overfit_pct=0.01)
 #### Print the parameter count by layer
 By default lightning prints a list of parameters *and submodules* when it starts training.
 
+``` {.python}
+# DEFAULT print a full list of all submodules and their parameters.
+trainer = Trainer(weights_summary='full')
+
+# only print the top-level modules (i.e. the children of LightningModule).
+trainer = Trainer(weights_summary='top')
+```
+
 ---
 #### Print which gradients are nan 
 This option prints a list of tensors with nan gradients.

--- a/docs/examples/Examples.md
+++ b/docs/examples/Examples.md
@@ -1,5 +1,5 @@
 ### Template model definition
-In 99% of cases you want to just copy [this template](https://github.com/williamFalcon/pytorch-lightning/blob/master/examples/new_project_templates/lightning_module_template.py) to start a new lightningModule and change the core of what your model is actually trying to do.
+In 99% of cases you want to just copy [one of the examples](https://github.com/williamFalcon/pytorch-lightning/tree/master/examples) to start a new lightningModule and change the core of what your model is actually trying to do.
 
 ```bash
 # get a copy of the module template

--- a/examples/basic_examples/lightning_module_template.py
+++ b/examples/basic_examples/lightning_module_template.py
@@ -98,8 +98,11 @@ class LightningTemplateModel(LightningModule):
         if self.trainer.use_dp or self.trainer.use_ddp2:
             loss_val = loss_val.unsqueeze(0)
 
+        tqdm_dict = {'train_loss': loss_val}
         output = OrderedDict({
-            'loss': loss_val
+            'loss': loss_val,
+            'progress_bar': tqdm_dict,
+            'loss': tqdm_dict
         })
 
         # can also return just a scalar instead of a dict (return loss_val)

--- a/examples/basic_examples/lightning_module_template.py
+++ b/examples/basic_examples/lightning_module_template.py
@@ -102,7 +102,7 @@ class LightningTemplateModel(LightningModule):
         output = OrderedDict({
             'loss': loss_val,
             'progress_bar': tqdm_dict,
-            'loss': tqdm_dict
+            'log': tqdm_dict
         })
 
         # can also return just a scalar instead of a dict (return loss_val)
@@ -171,7 +171,7 @@ class LightningTemplateModel(LightningModule):
         val_loss_mean /= len(outputs)
         val_acc_mean /= len(outputs)
         tqdm_dict = {'val_loss': val_loss_mean, 'val_acc': val_acc_mean}
-        result = {'progress_bar': tqdm_dict, 'logs': tqdm_dict}
+        result = {'progress_bar': tqdm_dict, 'log': tqdm_dict}
         return result
 
     # ---------------------

--- a/pytorch_lightning/callbacks/pt_callbacks.py
+++ b/pytorch_lightning/callbacks/pt_callbacks.py
@@ -125,7 +125,8 @@ class EarlyStopping(Callback):
             print('Early stopping conditioned on metric `%s` '
                   'which is not available. Available metrics are: %s' %
                   (self.monitor, ','.join(list(logs.keys()))), RuntimeWarning)
-            exit(-1)
+            stop_training = True
+            return stop_training
 
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current

--- a/pytorch_lightning/root_module/root_module.py
+++ b/pytorch_lightning/root_module/root_module.py
@@ -159,8 +159,8 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
 
         return model
 
-    def summarize(self):
-        model_summary = ModelSummary(self)
+    def summarize(self, mode):
+        model_summary = ModelSummary(self, mode=mode)
         print(model_summary)
 
     def freeze(self):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -84,7 +84,7 @@ class Trainer(TrainerIO):
                  distributed_backend=None,
                  use_amp=False,
                  print_nan_grads=False,
-                 print_weights_summary=True,
+                 weights_summary='full',
                  weights_save_path=None,
                  amp_level='O1',
                  nb_sanity_val_steps=5):
@@ -116,7 +116,7 @@ class Trainer(TrainerIO):
         :param distributed_backend: str. Options: 'dp', 'ddp', 'ddp2'.
         :param use_amp: Bool. If true uses apex for 16bit precision
         :param print_nan_grads: Bool. Prints nan gradients
-        :param print_weights_summary: Bool. Prints summary of weights
+        :param weights_summary: str. Options: 'full', 'top'.
         :param weights_save_path: Bool. Where to save weights if on cluster
         :param amp_level: str. Check nvidia docs for level
         :param nb_sanity_val_steps: int. How many val steps before a full train loop.
@@ -131,7 +131,7 @@ class Trainer(TrainerIO):
         self.fast_dev_run = fast_dev_run
         self.on_gpu = gpus is not None and torch.cuda.is_available()
         self.process_position = process_position
-        self.print_weights_summary = print_weights_summary
+        self.weights_summary = weights_summary
         self.max_nb_epochs = max_nb_epochs
         self.min_nb_epochs = min_nb_epochs
         self.nb_sanity_val_steps = nb_sanity_val_steps
@@ -981,8 +981,8 @@ class Trainer(TrainerIO):
         self.__layout_bookeeping()
 
         # print model summary
-        if self.proc_rank == 0 and self.print_weights_summary:
-            ref_model.summarize()
+        if self.proc_rank == 0 and self.weights_summary in ['full', 'top']:
+            ref_model.summarize(mode=self.weights_summary)
 
         # link up experiment object
         if self.logger is not None:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -975,6 +975,10 @@ class Trainer(TrainerIO):
         # register auto-resubmit when on SLURM
         self.register_slurm_signal_handlers()
 
+        # track model
+        # if cluster resets state, the model will update with the saved weights
+        self.model = model
+
         # restore training and model before hpc call
         self.restore_weights(model)
 
@@ -996,10 +1000,6 @@ class Trainer(TrainerIO):
             if hasattr(ref_model, "hparams"):
                 self.logger.log_hyperparams(ref_model.hparams)
             self.logger.save()
-
-        # track model now.
-        # if cluster resets state, the model will update with the saved weights
-        self.model = model
 
         # progress bar init
         if self.show_progress_bar:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1462,6 +1462,5 @@ class Trainer(TrainerIO):
 
         # model checkpointing
         if self.proc_rank == 0 and self.checkpoint_callback is not None and not test:
-            print('save callback...')
             self.checkpoint_callback.on_epoch_end(epoch=self.current_epoch,
                                                   logs=self.__training_tqdm_dict)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -975,6 +975,9 @@ class Trainer(TrainerIO):
         # register auto-resubmit when on SLURM
         self.register_slurm_signal_handlers()
 
+        # restore training and model before hpc call
+        self.restore_weights(model)
+
         # transfer data loaders from model
         self.get_dataloaders(ref_model)
 
@@ -997,9 +1000,6 @@ class Trainer(TrainerIO):
         # track model now.
         # if cluster resets state, the model will update with the saved weights
         self.model = model
-
-        # restore training and model before hpc call
-        self.restore_weights(model)
 
         # progress bar init
         if self.show_progress_bar:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -148,6 +148,7 @@ class Trainer(TrainerIO):
         self.avg_loss = 0
         self.batch_nb = 0
         self.tqdm_metrics = {}
+        self.callback_metrics = {}
         self.nb_val_batches = 0
         self.nb_training_batches = 0
         self.nb_test_batches = 0
@@ -1061,7 +1062,7 @@ class Trainer(TrainerIO):
             met_min_epochs = epoch_nb > self.min_nb_epochs
             if self.enable_early_stop and met_min_epochs:
                 should_stop = self.early_stop_callback.on_epoch_end(epoch=epoch_nb,
-                                                                    logs=self.__training_tqdm_dict)
+                                                                    logs=self.callback_metrics)
                 # stop training
                 stop = should_stop and met_min_epochs
                 if stop:
@@ -1237,8 +1238,9 @@ class Trainer(TrainerIO):
             output = self.model.training_step(*args)
 
         # format and reduce outputs accordingly
-        loss, progress_bar_metrics, log_metrics = self.__process_output(output, train=True)
-        return loss, progress_bar_metrics, log_metrics
+        output = self.__process_output(output, train=True)
+        loss, progress_bar_metrics, log_metrics, callback_metrics = output
+        return loss, progress_bar_metrics, log_metrics, callback_metrics
 
     def __process_output(self, output, train=False):
         """
@@ -1247,6 +1249,12 @@ class Trainer(TrainerIO):
         :param output:
         :return:
         """
+        # all keys not progress_bar or log are candidates for callbacks
+        callback_metrics = {}
+        for k, v in output.items():
+            if k not in ['progress_bar', 'log']:
+                callback_metrics[k] = v
+
         try:
             progress_output = output['progress_bar']
 
@@ -1293,7 +1301,7 @@ class Trainer(TrainerIO):
             if self.use_dp or self.use_ddp2:
                 loss = reduce_distributed_output(loss, self.num_gpus)
 
-        return loss, progress_bar_metrics, log_metrics
+        return loss, progress_bar_metrics, log_metrics, callback_metrics
 
     def __clip_gradients(self):
         if self.gradient_clip_val > 0:
@@ -1309,6 +1317,9 @@ class Trainer(TrainerIO):
     def __run_training_batch(self, batch, batch_nb):
         # track grad norms
         grad_norm_dic = {}
+
+        # track all metrics for callbacks
+        all_callback_metrics = []
 
         # track metrics to log
         all_log_metrics = []
@@ -1334,7 +1345,10 @@ class Trainer(TrainerIO):
             def optimizer_closure():
                 # forward pass
                 output = self.__training_forward(batch, batch_nb, opt_idx)
-                closure_loss, progress_bar_metrics, log_metrics = output
+                closure_loss, progress_bar_metrics, log_metrics, callback_metrics = output
+
+                # track metrics for callbacks
+                all_callback_metrics.append(callback_metrics)
 
                 # track progress bar metrics
                 self.__add_tqdm_metrics(progress_bar_metrics)
@@ -1404,6 +1418,10 @@ class Trainer(TrainerIO):
 
         # collapse all metrics into one dict
         all_log_metrics = {k: v for d in all_log_metrics for k, v in d.items()}
+
+        # track all metrics for callbacks
+        self.callback_metrics = {k: v for d in all_callback_metrics for k, v in d.items()}
+
         return 0, grad_norm_dic, all_log_metrics
 
     def __run_evaluation(self, test=False):
@@ -1444,13 +1462,16 @@ class Trainer(TrainerIO):
                                          dataloaders,
                                          max_batches,
                                          test)
-            _, progress_bar_metrics, log_metrics = self.__process_output(eval_results)
+            _, prog_bar_metrics, log_metrics, callback_metrics = self.__process_output(eval_results)
 
             # add metrics to prog bar
-            self.__add_tqdm_metrics(progress_bar_metrics)
+            self.__add_tqdm_metrics(prog_bar_metrics)
 
             # log metrics
             self.__log_metrics(log_metrics, {})
+
+            # track metrics for callbacks
+            self.callback_metrics = callback_metrics
 
             # hook
             model.on_post_performance_check()
@@ -1463,4 +1484,4 @@ class Trainer(TrainerIO):
         # model checkpointing
         if self.proc_rank == 0 and self.checkpoint_callback is not None and not test:
             self.checkpoint_callback.on_epoch_end(epoch=self.current_epoch,
-                                                  logs=self.__training_tqdm_dict)
+                                                  logs=self.callback_metrics)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -86,7 +86,7 @@ class Trainer(TrainerIO):
                  print_nan_grads=False,
                  print_weights_summary=True,
                  weights_save_path=None,
-                 amp_level='O2',
+                 amp_level='O1',
                  nb_sanity_val_steps=5):
         """
 


### PR DESCRIPTION
Loads weights before calling dataloaders so there's more free memory available to restore weights. However, the main OOM issue in apex is likely caused by the way apex loads weights which doubles memory footprint