### PR TITLE
Finalize logger

### DIFF
--- a/pytorch_lightning/logging/mlflow_logger.py
+++ b/pytorch_lightning/logging/mlflow_logger.py
@@ -53,4 +53,6 @@ class MLFlowLogger(LightningLoggerBase):
 
     @rank_zero_only
     def finalize(self, status="FINISHED"):
+        if status == 'success':
+            status = 'FINISHED'
         self.client.set_terminated(self.run_id, status)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1068,7 +1068,7 @@ class Trainer(TrainerIO):
                     return
         
         if self.logger is not None:
-            self.logger.finalize()
+            self.logger.finalize("success")
 
     def run_training_epoch(self):
         # before epoch hook

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1066,6 +1066,9 @@ class Trainer(TrainerIO):
                 stop = should_stop and met_min_epochs
                 if stop:
                     return
+        
+        if self.logger is not None:
+            self.logger.finalize()
 
     def run_training_epoch(self):
         # before epoch hook

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1066,7 +1066,7 @@ class Trainer(TrainerIO):
                 stop = should_stop and met_min_epochs
                 if stop:
                     return
-        
+
         if self.logger is not None:
             self.logger.finalize("success")
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -153,8 +153,8 @@ def test_custom_logger():
             self.metrics_logged = metrics
         
         @rank_zero_only
-        def finalize(self):
-            self.finalized = True
+        def finalize(self, status):
+            self.finalized_status = status
 
     hparams = get_hparams()
     model = LightningTestModel(hparams)
@@ -172,7 +172,7 @@ def test_custom_logger():
     assert result == 1, "Training failed"
     assert logger.hparams_logged == hparams
     assert logger.metrics_logged != {}
-    assert logger.finalized
+    assert logger.finalized_status == "success"
 
 
 def reset_seed():

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -151,7 +151,7 @@ def test_custom_logger():
         @rank_zero_only
         def log_metrics(self, metrics, step_num):
             self.metrics_logged = metrics
-        
+
         @rank_zero_only
         def finalize(self, status):
             self.finalized_status = status


### PR DESCRIPTION
Call `logger.finalize` after training is complete. Also adds a test to ensure custom loggers work. Fixes #316.

Waiting for clarification on `log_hyperparams` not being called.