### PR TITLE
Fix number of batches is off-by-one during training

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1127,7 +1127,7 @@ class Trainer(TrainerIO):
             # stop when the flag is changed or we've gone past the amount
             #  requested in the batches
             self.total_batch_nb += 1
-            met_batch_limit = batch_nb > self.nb_training_batches
+            met_batch_limit = batch_nb >= self.nb_training_batches
             if met_batch_limit:
                 break
 


### PR DESCRIPTION
Fixes https://github.com/williamFalcon/pytorch-lightning/issues/371.

Could you let me know if/how this change should be tested, as the existing tests for e.g. the early stop callback seems quite simple?