### PR TITLE
[Doc] Fixed link to trainer.py github code

### DIFF
--- a/docs/Trainer/index.md
+++ b/docs/Trainer/index.md
@@ -1,5 +1,5 @@
 # Trainer
-[[Github Code](https://github.com/williamFalcon/pytorch-lightning/blob/master/pytorch_lightning/models/trainer.py)]
+[[Github Code](https://github.com/williamFalcon/pytorch-lightning/blob/master/pytorch_lightning/trainer/trainer.py)]
 
 The lightning trainer abstracts best practices for running a training, val, test routine. It calls parts of your model when it wants to hand over full control and otherwise makes training assumptions which are now standard practice in AI research.
 


### PR DESCRIPTION
## What does this PR do?
Fixes the broken link to trainer.py file from https://github.com/williamFalcon/pytorch-lightning/blob/master/pytorch_lightning/models/trainer.py to https://github.com/williamFalcon/pytorch-lightning/blob/master/pytorch_lightning/trainer/trainer.py
