### PR TITLE
bug fixed  #403 callbacks=False or None

### DIFF
--- a/pytorch_lightning/trainer/trainer_io.py
+++ b/pytorch_lightning/trainer/trainer_io.py
@@ -151,10 +151,10 @@ class TrainerIOMixin(object):
             'global_step': self.global_step
         }
 
-        if self.checkpoint_callback is not None or self.checkpoint_callback is not False:
+        if self.checkpoint_callback is not None and self.checkpoint_callback is not False:
             checkpoint['checkpoint_callback_best'] = self.checkpoint_callback.best
 
-        if self.early_stop_callback is not None or self.checkpoint_callback is not False:
+        if self.early_stop_callback is not None and self.checkpoint_callback is not False:
             checkpoint['early_stop_callback_wait'] = self.early_stop_callback.wait
             checkpoint['early_stop_callback_patience'] = self.early_stop_callback.patience
 
@@ -207,10 +207,10 @@ class TrainerIOMixin(object):
         :param checkpoint:
         :return:
         """
-        if self.checkpoint_callback is not None or self.checkpoint_callback is not False:
+        if self.checkpoint_callback is not None and self.checkpoint_callback is not False:
             self.checkpoint_callback.best = checkpoint['checkpoint_callback_best']
 
-        if self.early_stop_callback is not None or self.early_stop_callback is not False:
+        if self.early_stop_callback is not None and self.early_stop_callback is not False:
             self.early_stop_callback.wait = checkpoint['early_stop_callback_wait']
             self.early_stop_callback.patience = checkpoint['early_stop_callback_patience']
 


### PR DESCRIPTION
This is a fix for #403.

# Before submitting

- Was this discussed/approved via a Github issue?  yes
- Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)? yes
- Did you make sure to update the docs?   
- Did you write any new necessary tests?  No

## What does this PR do?
When callbacks=False or None, `early_stoppling_callback.wait` is called.
I modify if sentences from `or` to `and`.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.   
