### PR TITLE
moved COMET_DISABLE_AUTO_LOGGING out of modeule for flake8 compliance

### DIFF
--- a/pytorch_lightning/logging/__init__.py
+++ b/pytorch_lightning/logging/__init__.py
@@ -10,8 +10,9 @@ try:
 except ModuleNotFoundError:
     pass
 try:
+    from .comet_logger import CometLogger
+
     # needed to prevent ImportError and duplicated logs.
     environ["COMET_DISABLE_AUTO_LOGGING"] = "1"
-    from .comet_logger import CometLogger
 except ModuleNotFoundError:
     pass

--- a/pytorch_lightning/logging/__init__.py
+++ b/pytorch_lightning/logging/__init__.py
@@ -1,3 +1,4 @@
+from os import environ
 from .base import LightningLoggerBase, rank_zero_only
 
 try:
@@ -9,6 +10,8 @@ try:
 except ModuleNotFoundError:
     pass
 try:
+    # needed to prevent ImportError and duplicated logs.
+    environ["COMET_DISABLE_AUTO_LOGGING"] = "1"
     from .comet_logger import CometLogger
 except ModuleNotFoundError:
     pass

--- a/pytorch_lightning/logging/comet_logger.py
+++ b/pytorch_lightning/logging/comet_logger.py
@@ -4,9 +4,6 @@ from comet_ml import Experiment as CometExperiment
 
 from .base import LightningLoggerBase, rank_zero_only
 
-# needed to prevent ImportError and duplicated logs.
-environ["COMET_DISABLE_AUTO_LOGGING"] = "1"
-
 
 class CometLogger(LightningLoggerBase):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
# Before submitting

- Was this discussed/approved via a Github issue? NO
- Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)? YES
- Did you make sure to update the docs?   YES
- Did you write any new necessary tests?  NO

## What does this PR do?
Comet ML requires importing its module before others (eg. pytorch, tensorboard). This behaviour can be deactivated if COMET_DISABLE_AUTO_LOGGING is set to 1 BEFORE IMPORTING COMET. However, since this is against the rules enforced by flake8. This PR fixes all that by moving the env var definition to another module.
(SORRY)
