### PR TITLE
Move `global_step` incrementing

### DIFF
--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -83,6 +83,8 @@ class TrainerTrainLoopMixin(object):
             # ---------------
             output = self.run_training_batch(batch, batch_nb)
             batch_result, grad_norm_dic, batch_step_metrics = output
+
+            # when returning -1 from train_step, we end epoch early
             early_stop_epoch = batch_result == -1
 
             # ---------------
@@ -108,15 +110,16 @@ class TrainerTrainLoopMixin(object):
                 # logs user requested information to logger
                 self.log_metrics(batch_step_metrics, grad_norm_dic)
 
+            self.global_step += 1
+            self.total_batch_nb += 1
+
             # end epoch early
+            # stop when the flag is changed or we've gone past the amount
+            # requested in the batches
             if early_stop_epoch or self.fast_dev_run:
                 break
 
-            self.global_step += 1
-
-            # stop when the flag is changed or we've gone past the amount
-            #  requested in the batches
-            self.total_batch_nb += 1
+            # stop epoch if we limited nb batches
             met_batch_limit = batch_nb >= self.nb_training_batches
             if met_batch_limit:
                 break

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -113,7 +113,7 @@ class TrainerTrainLoopMixin(object):
                 break
 
             self.global_step += 1
-            
+
             # stop when the flag is changed or we've gone past the amount
             #  requested in the batches
             self.total_batch_nb += 1

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -78,13 +78,6 @@ class TrainerTrainLoopMixin(object):
             model = self.get_model()
             model.global_step = self.global_step
 
-            # stop when the flag is changed or we've gone past the amount
-            #  requested in the batches
-            self.total_batch_nb += 1
-            met_batch_limit = batch_nb >= self.nb_training_batches
-            if met_batch_limit:
-                break
-
             # ---------------
             # RUN TRAIN STEP
             # ---------------
@@ -120,6 +113,13 @@ class TrainerTrainLoopMixin(object):
                 break
 
             self.global_step += 1
+            
+            # stop when the flag is changed or we've gone past the amount
+            #  requested in the batches
+            self.total_batch_nb += 1
+            met_batch_limit = batch_nb >= self.nb_training_batches
+            if met_batch_limit:
+                break
 
         # epoch end hook
         if self.is_function_implemented('on_epoch_end'):

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -74,7 +74,6 @@ class TrainerTrainLoopMixin(object):
         # run epoch
         for batch_nb, batch in enumerate(self.get_train_dataloader()):
             self.batch_nb = batch_nb
-            self.global_step += 1
 
             model = self.get_model()
             model.global_step = self.global_step
@@ -119,6 +118,8 @@ class TrainerTrainLoopMixin(object):
             # end epoch early
             if early_stop_epoch or self.fast_dev_run:
                 break
+
+            self.global_step += 1
 
         # epoch end hook
         if self.is_function_implemented('on_epoch_end'):


### PR DESCRIPTION
Fix https://github.com/williamFalcon/pytorch-lightning/issues/411 by moving the global_step incrementing logic to the end of batch processing. This way step 0 should be able to fully complete before incrementing.