### PR TITLE
moved env var to before import

### DIFF
--- a/pytorch_lightning/logging/__init__.py
+++ b/pytorch_lightning/logging/__init__.py
@@ -10,9 +10,9 @@ try:
 except ModuleNotFoundError:
     pass
 try:
-    from .comet_logger import CometLogger
-
     # needed to prevent ImportError and duplicated logs.
     environ["COMET_DISABLE_AUTO_LOGGING"] = "1"
+
+    from .comet_logger import CometLogger
 except ModuleNotFoundError:
-    pass
+    del environ["COMET_DISABLE_AUTO_LOGGING"]


### PR DESCRIPTION
## What does this PR do?
Fixes ImportError when not importing comet_ml at the top of the main file.

# IMPORTANT: 
changing the order (setting env var after the import) breaks the PR