### PR TITLE
Save / Load Hyperparameters with checkpoint

### DIFF
--- a/.run_local_tests.sh
+++ b/.run_local_tests.sh
@@ -3,5 +3,6 @@ rm -rf _ckpt_*
 rm -rf tests/save_dir*
 rm -rf tests/mlruns_*
 rm -rf tests/tests/*
+rm -rf lightning_logs
 coverage run --source pytorch_lightning -m py.test pytorch_lightning tests pl_examples -v --doctest-modules
 coverage report -m

--- a/docs/LightningModule/methods.md
+++ b/docs/LightningModule/methods.md
@@ -10,8 +10,25 @@ model.freeze()
 
 ---    
 ### load_from_metrics
-This is the easiest/fastest way which uses the meta_tags.csv file from test-tube to rebuild the model.
-The meta_tags.csv file can be found in the test-tube experiment save_dir.       
+This is the easiest/fastest way which loads hyperparameters and weights from a checkpoint,
+such as the one saved by the `ModelCheckpoint` callback
+
+```{.python}
+pretrained_model = MyLightningModule.load_from_checkpoint(
+    checkpoint_path='/path/to/pytorch_checkpoint.ckpt'
+)
+    
+# predict
+pretrained_model.eval()
+pretrained_model.freeze()
+y_hat = pretrained_model(x)
+```
+
+---    
+### load_from_metrics
+If you're using test tube, there is an alternate method which uses the meta_tags.csv
+file from test-tube to rebuild the model. The meta_tags.csv file can be found in the
+test-tube experiment save_dir.       
 
 ```{.python}
 pretrained_model = MyLightningModule.load_from_metrics(

--- a/pl_examples/basic_examples/lightning_module_template.py
+++ b/pl_examples/basic_examples/lightning_module_template.py
@@ -158,7 +158,7 @@ class LightningTemplateModel(LightningModule):
             val_loss = output['val_loss']
 
             # reduce manually when using dp
-            if self.trainer.use_dp:
+            if self.trainer.use_dp or self.trainer.use_ddp2:
                 val_loss = torch.mean(val_loss)
             val_loss_mean += val_loss
 

--- a/pytorch_lightning/root_module/root_module.py
+++ b/pytorch_lightning/root_module/root_module.py
@@ -1,4 +1,5 @@
 import warnings
+from argparse import Namespace
 
 import torch
 
@@ -167,6 +168,36 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
         # load on CPU only to avoid OOM issues
         # then its up to user to put back on GPUs
         checkpoint = torch.load(weights_path, map_location=lambda storage, loc: storage)
+
+        # load the state_dict on the model automatically
+        model = cls(hparams)
+        model.load_state_dict(checkpoint['state_dict'])
+
+        # give model a chance to load something
+        model.on_load_checkpoint(checkpoint)
+
+        return model
+
+    @classmethod
+    def load_from_checkpoint(cls, checkpoint_path):
+        """
+        Primary way of loading model from a checkpoint
+        :param checkpoint_path:
+        :param map_location: dic for mapping storage {'cuda:1':'cuda:0'}
+        :return:
+        """
+
+        # load on CPU only to avoid OOM issues
+        # then its up to user to put back on GPUs
+        checkpoint = torch.load(checkpoint_path, map_location=lambda storage, loc: storage)
+        try:
+            ckpt_hparams = checkpoint['hparams']
+        except KeyError:
+            raise IOError(
+                "Checkpoint does not contain hyperparameters. Are your model hyperparameters stored"
+                "in self.hparams?"
+            )
+        hparams = Namespace(**ckpt_hparams)
 
         # load the state_dict on the model automatically
         model = cls(hparams)

--- a/pytorch_lightning/testing/lm_test_module_mixins.py
+++ b/pytorch_lightning/testing/lm_test_module_mixins.py
@@ -80,13 +80,13 @@ class LightningValidationMixin(LightningValidationStepMixin):
             val_loss = output['val_loss']
 
             # reduce manually when using dp
-            if self.trainer.use_dp:
+            if self.trainer.use_dp or self.trainer.use_ddp2:
                 val_loss = torch.mean(val_loss)
             val_loss_mean += val_loss
 
             # reduce manually when using dp
             val_acc = output['val_acc']
-            if self.trainer.use_dp:
+            if self.trainer.use_dp or self.trainer.use_ddp2:
                 val_acc = torch.mean(val_acc)
 
             val_acc_mean += val_acc

--- a/pytorch_lightning/trainer/trainer_io.py
+++ b/pytorch_lightning/trainer/trainer_io.py
@@ -1,6 +1,7 @@
 import os
 import re
 import signal
+import warnings
 from subprocess import call
 
 import torch

--- a/pytorch_lightning/trainer/trainer_io.py
+++ b/pytorch_lightning/trainer/trainer_io.py
@@ -175,7 +175,13 @@ class TrainerIOMixin(object):
         # add the hparams and state_dict from the model
         model = self.get_model()
         checkpoint['state_dict'] = model.state_dict()
-        checkpoint['hparams'] = vars(model.hparams)
+        if hasattr(model, "hparams"):
+            checkpoint['hparams'] = vars(model.hparams)
+        else:
+            warnings.warn(
+                "Did not find hyperparameters at model.hparams. Saving checkpoint without"
+                " hyperparameters"
+            )
 
         # give the model a chance to add a few things
         model.on_save_checkpoint(checkpoint)

--- a/pytorch_lightning/trainer/trainer_io.py
+++ b/pytorch_lightning/trainer/trainer_io.py
@@ -172,9 +172,10 @@ class TrainerIOMixin(object):
 
         checkpoint['lr_schedulers'] = lr_schedulers
 
-        # add the state_dict from the model
+        # add the hparams and state_dict from the model
         model = self.get_model()
         checkpoint['state_dict'] = model.state_dict()
+        checkpoint['hparams'] = vars(model.hparams)
 
         # give the model a chance to add a few things
         model.on_save_checkpoint(checkpoint)


### PR DESCRIPTION
Right now, test tube users can have `model.load_from_metrics`, but there's no equivalent functionality for users of other logging frameworks. I believe we discussed a while ago that this functionality should be decoupled from loggers. This PR adds functionality to save and load hyperparameters using the standard checkpoint mechanism

* If users store hyperparams as an `argparse.Namespace` in `model.hparams`, they'll automatically be saved with checkpoints.
* Added a `load_from_checkpoint` classmethod to LightningModule that loads a model with hyperparameters from a checkpoint.

Resolves #406 