### PR TITLE
clear memory cache before train starts

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -447,6 +447,10 @@ class Trainer(TrainerIOMixin,
 
             self.evaluate(model, self.get_val_dataloaders(), self.nb_sanity_val_steps, self.testing)
 
+        # clear cache before training
+        if self.on_gpu:
+            torch.cuda.empty_cache()
+
         # CORE TRAINING LOOP
         self.train()
 

--- a/tests/test_restore_models.py
+++ b/tests/test_restore_models.py
@@ -327,7 +327,8 @@ def test_cpu_restore_training():
 
     # set the epoch start hook so we can predict before the model does the full training
     def assert_good_acc():
-        assert trainer.current_epoch == real_global_epoch and trainer.current_epoch > 0
+        assert trainer.current_epoch > 0
+        assert trainer.current_epoch == real_global_epoch
 
         # if model and state loaded correctly, predictions will be good even though we
         # haven't trained with the new loaded model


### PR DESCRIPTION
Clears GPU mem when training loop starts. 
Should help when restoring training on GPU