### PR TITLE
Set total number of batches in progress bar while testing

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -432,6 +432,9 @@ class Trainer(TrainerIOMixin,
 
         # when testing requested only run test and return
         if self.testing:
+            if self.show_progress_bar:
+                self.progress_bar.reset(self.nb_test_batches)
+
             self.run_evaluation(test=True)
             return
 


### PR DESCRIPTION
Now progress bar doesn't show total number of batches in test mode. This PR fixes it.