### PR TITLE
makes checkpoint process safe

### DIFF
--- a/pytorch_lightning/trainer/trainer_io.py
+++ b/pytorch_lightning/trainer/trainer_io.py
@@ -137,7 +137,13 @@ class TrainerIOMixin(object):
         checkpoint = self.dump_checkpoint()
 
         # do the actual save
-        torch.save(checkpoint, filepath)
+        try:
+            torch.save(checkpoint, filepath)
+        except AttributeError:
+            if 'hparams' in checkpoint:
+                del checkpoint['hparams']
+
+            torch.save(checkpoint, filepath)
 
     def restore(self, checkpoint_path, on_gpu):
 
@@ -283,7 +289,14 @@ class TrainerIOMixin(object):
         model.on_hpc_save(checkpoint)
 
         # do the actual save
-        torch.save(checkpoint, filepath)
+        # TODO: fix for anything with multiprocess DP, DDP, DDP2
+        try:
+            torch.save(checkpoint, filepath)
+        except AttributeError:
+            if 'hparams' in checkpoint:
+                del checkpoint['hparams']
+
+            torch.save(checkpoint, filepath)
 
         return filepath
 


### PR DESCRIPTION
@neggert looks like the hparams saving fails with ddp/ddp2

  File "/private/home/falc/.conda/envs/ddt2/lib/python3.7/site-packages/pytorch_lightning/callbacks/pt_callbacks.py", line 245, in on_epoch_end
    self.save_model(filepath, overwrite=True)
  File "/private/home/falc/.conda/envs/ddt2/lib/python3.7/site-packages/pytorch_lightning/callbacks/pt_callbacks.py", line 224, in save_model
    self.save_function(filepath)
  File "/private/home/falc/.conda/envs/ddt2/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer_io.py", line 127, in save_checkpoint
    torch.save(checkpoint, filepath)
  File "/private/home/falc/.local/lib/python3.7/site-packages/torch/serialization.py", line 224, in save
    return _with_file_like(f, "wb", lambda f: _save(obj, f, pickle_module, pickle_protocol))
  File "/private/home/falc/.local/lib/python3.7/site-packages/torch/serialization.py", line 149, in _with_file_like
    return body(f)
  File "/private/home/falc/.local/lib/python3.7/site-packages/torch/serialization.py", line 224, in <lambda>
    return _with_file_like(f, "wb", lambda f: _save(obj, f, pickle_module, pickle_protocol))
  File "/private/home/falc/.local/lib/python3.7/site-packages/torch/serialization.py", line 296, in _save
    pickler.dump(obj)
AttributeError: Can't pickle local object 'ArgumentParser.__init__.<locals>.identity'