### PR TITLE
Update Docs for current checkpointing behaviour

### DIFF
--- a/docs/Trainer/Checkpointing.md
+++ b/docs/Trainer/Checkpointing.md
@@ -32,12 +32,19 @@ You might want to not only load a model but also continue training it. Use this 
 restore the trainer state as well. This will continue from the epoch and global step you last left off.  
 However, the dataloaders will start from the first batch again (if you shuffled it shouldn't matter).   
 
-Lightning will restore the session if you pass an experiment with the same version and there's a saved checkpoint.   
+Lightning will restore the session if you pass a logger with the same version and there's a saved checkpoint.   
 ``` {.python}
-from test_tube import Experiment
+from pytorch_lightning import Trainer
+from pytorch_lightning.logging import TestTubeLogger
 
-exp = Experiment(version=a_previous_version_with_a_saved_checkpoint)
-trainer = Trainer(experiment=exp)
+logger = TestTubeLogger(
+    save_dir='./savepath',
+    version=1  # An existing version with a saved checkpoint
+)
+trainer = Trainer(
+    logger=logger,
+    default_save_path='./savepath'
+)
 
 # this fit call loads model weights and trainer state
 # the trainer continues seamlessly from where you left off


### PR DESCRIPTION
# Before submitting

- Was this discussed/approved via a Github issue? **Related issue #432**
- Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)? **Yes**
- Did you make sure to update the docs? **Yes**
- Did you write any new necessary tests?  **N/A**

## What does this PR do?
Fixes #432.

The old documentation suggested that the way to restore a training session is to use a test_tube `Experiment`. `Trainer` no longer takes an experiment as a parameter, so it seems the current way to restore a training session is to pass an experiment via a `TestTubeLogger`. Even if this is not the most elegant solution, updating the docs will at least point new users in the right direction.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.   

## Did you have fun?
Make sure you had fun coding 🙃
