### PR TITLE
Split progress bar

### DIFF
--- a/pytorch_lightning/trainer/evaluation_loop_mixin.py
+++ b/pytorch_lightning/trainer/evaluation_loop_mixin.py
@@ -119,12 +119,14 @@ class TrainerEvaluationLoopMixin(object):
                 # main progress bar will already be closed when testing so initial position is free
                 pbar = tqdm.tqdm(desc='Testing', total=max_batches,
                                  leave=True, position=2 * self.process_position,
-                                 disable=not self.show_progress_bar)
+                                 disable=not self.show_progress_bar, dynamic_ncols=True,
+                                 unit='batch')
                 self.test_progress_bar = pbar
             else:
                 pbar = tqdm.tqdm(desc='Validating', total=max_batches,
                                  leave=False, position=2 * self.process_position + 1,
-                                 disable=not self.show_progress_bar)
+                                 disable=not self.show_progress_bar, dynamic_ncols=True,
+                                 unit='batch')
                 self.val_progress_bar = pbar
 
             # run evaluation

--- a/pytorch_lightning/trainer/evaluation_loop_mixin.py
+++ b/pytorch_lightning/trainer/evaluation_loop_mixin.py
@@ -115,19 +115,13 @@ class TrainerEvaluationLoopMixin(object):
                 max_batches = 1
 
             # init validation or test progress bar
-            if test:
-                # main progress bar will already be closed when testing so initial position is free
-                pbar = tqdm.tqdm(desc='Testing', total=max_batches,
-                                 leave=True, position=2 * self.process_position,
-                                 disable=not self.show_progress_bar, dynamic_ncols=True,
-                                 unit='batch')
-                self.test_progress_bar = pbar
-            else:
-                pbar = tqdm.tqdm(desc='Validating', total=max_batches,
-                                 leave=False, position=2 * self.process_position + 1,
-                                 disable=not self.show_progress_bar, dynamic_ncols=True,
-                                 unit='batch')
-                self.val_progress_bar = pbar
+            # main progress bar will already be closed when testing so initial position is free
+            position = 2 * self.process_position + (not test)
+            desc = 'Testing' if test else 'Validating'
+            pbar = tqdm.tqdm(desc=desc, total=max_batches, leave=test, position=position,
+                             disable=not self.show_progress_bar, dynamic_ncols=True,
+                             unit='batch')
+            setattr(self, f'{"test" if test else "val"}_progress_bar', pbar)
 
             # run evaluation
             eval_results = self.evaluate(self.model,

--- a/pytorch_lightning/trainer/evaluation_loop_mixin.py
+++ b/pytorch_lightning/trainer/evaluation_loop_mixin.py
@@ -1,4 +1,5 @@
 import torch
+import tqdm
 
 from pytorch_lightning.utilities.debugging import MisconfigurationException
 
@@ -52,8 +53,11 @@ class TrainerEvaluationLoopMixin(object):
                 dl_outputs.append(output)
 
                 # batch done
-                if self.show_progress_bar:
-                    self.progress_bar.update(1)
+                if test:
+                    self.test_progress_bar.update(1)
+                else:
+                    self.val_progress_bar.update(1)
+                    self.main_progress_bar.update(1)
             outputs.append(dl_outputs)
 
         eval_results = {}
@@ -110,6 +114,19 @@ class TrainerEvaluationLoopMixin(object):
             if self.fast_dev_run:
                 max_batches = 1
 
+            # init validation or test progress bar
+            if test:
+                # main progress bar will already be closed when testing so initial position is free
+                pbar = tqdm.tqdm(desc='Testing', total=max_batches,
+                                 leave=True, position=2 * self.process_position,
+                                 disable=not self.show_progress_bar)
+                self.test_progress_bar = pbar
+            else:
+                pbar = tqdm.tqdm(desc='Validating', total=max_batches,
+                                 leave=False, position=2 * self.process_position + 1,
+                                 disable=not self.show_progress_bar)
+                self.val_progress_bar = pbar
+
             # run evaluation
             eval_results = self.evaluate(self.model,
                                          dataloaders,
@@ -129,10 +146,16 @@ class TrainerEvaluationLoopMixin(object):
             # hook
             model.on_post_performance_check()
 
-            if self.show_progress_bar:
-                # add model specific metrics
-                tqdm_metrics = self.training_tqdm_dict
-                self.progress_bar.set_postfix(**tqdm_metrics)
+            # add model specific metrics
+            tqdm_metrics = self.training_tqdm_dict
+            if not test:
+                self.main_progress_bar.set_postfix(**tqdm_metrics)
+
+            # close progress bar
+            if test:
+                self.test_progress_bar.close()
+            else:
+                self.val_progress_bar.close()
 
         # model checkpointing
         if self.proc_rank == 0 and self.checkpoint_callback is not None and not test:

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -1,4 +1,5 @@
 import numpy as np
+import tqdm
 
 try:
     from apex import amp
@@ -34,18 +35,20 @@ class TrainerTrainLoopMixin(object):
                                   self.nb_val_batches * val_checks_per_epoch)
             self.batch_loss_value = 0  # accumulated grads
 
-            # limit the number of batches to 1 in fast_dev_run
+            nb_iterations = self.total_batches
+
+            #  for iterable train loader, the progress bar never ends
+            if self.is_iterable_train_dataloader:
+                nb_iterations = float('inf')
+
+            # limit the number of batches to 2 (1 train and 1 val) in fast_dev_run
             if self.fast_dev_run:
-                self.total_batches = 1
+                nb_iterations = 2
 
-            # init progress_bar when requested
-            if self.show_progress_bar:
-                nb_iterations = self.total_batches
-
-                #  for iterable train loader, the progress bar never ends
-                if self.is_iterable_train_dataloader:
-                    nb_iterations = float('inf')
-                self.progress_bar.reset(nb_iterations)
+            # reset progress bar
+            self.main_progress_bar.reset(nb_iterations)
+            desc = f'Epoch {epoch_nb}' if not self.is_iterable_train_dataloader else ''
+            self.main_progress_bar.set_description(desc)
 
             # changing gradient according accumulation_scheduler
             self.accumulation_scheduler.on_epoch_begin(epoch_nb, self)
@@ -68,7 +71,10 @@ class TrainerTrainLoopMixin(object):
                 # stop training
                 stop = should_stop and met_min_epochs
                 if stop:
+                    self.main_progress_bar.close()
                     return
+
+        self.main_progress_bar.close()
 
         if self.logger is not None:
             self.logger.finalize("success")
@@ -158,9 +164,6 @@ class TrainerTrainLoopMixin(object):
             if response == -1:
                 return -1, grad_norm_dic
 
-        if self.show_progress_bar:
-            self.progress_bar.update(1)
-
         # call training_step once per optimizer
         for opt_idx, optimizer in enumerate(self.optimizers):
 
@@ -226,16 +229,14 @@ class TrainerTrainLoopMixin(object):
                 self.batch_loss_value = 0
                 self.avg_loss = np.mean(self.running_loss[-100:])
 
-                # update progress bar
-                if self.show_progress_bar:
-                    # add model specific metrics
-                    tqdm_metrics = self.training_tqdm_dict
-                    self.progress_bar.set_postfix(**tqdm_metrics)
-
         # activate batch end hook
         if self.is_function_implemented('on_batch_end'):
             model = self.get_model()
             model.on_batch_end()
+
+        # update progress bar
+        self.main_progress_bar.update(1)
+        self.main_progress_bar.set_postfix(**self.training_tqdm_dict)
 
         # collapse all metrics into one dict
         all_log_metrics = {k: v for d in all_log_metrics for k, v in d.items()}

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -35,15 +35,14 @@ class TrainerTrainLoopMixin(object):
                                   self.nb_val_batches * val_checks_per_epoch)
             self.batch_loss_value = 0  # accumulated grads
 
-            nb_iterations = self.total_batches
-
-            #  for iterable train loader, the progress bar never ends
-            if self.is_iterable_train_dataloader:
-                nb_iterations = None
-
-            # limit the number of batches to 2 (1 train and 1 val) in fast_dev_run
             if self.fast_dev_run:
+                # limit the number of batches to 2 (1 train and 1 val) in fast_dev_run
                 nb_iterations = 2
+            elif self.is_iterable_train_dataloader:
+                # for iterable train loader, the progress bar never ends
+                nb_iterations = None
+            else:
+                nb_iterations = self.total_batches
 
             # reset progress bar
             # .reset() doesn't work on disabled progress bar so we should check

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -39,7 +39,7 @@ class TrainerTrainLoopMixin(object):
 
             #  for iterable train loader, the progress bar never ends
             if self.is_iterable_train_dataloader:
-                nb_iterations = float('inf')
+                nb_iterations = None
 
             # limit the number of batches to 2 (1 train and 1 val) in fast_dev_run
             if self.fast_dev_run:

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -46,7 +46,9 @@ class TrainerTrainLoopMixin(object):
                 nb_iterations = 2
 
             # reset progress bar
-            self.main_progress_bar.reset(nb_iterations)
+            # .reset() doesn't work on disabled progress bar so we should check
+            if not self.main_progress_bar.disable:
+                self.main_progress_bar.reset(nb_iterations)
             desc = f'Epoch {epoch_nb + 1}' if not self.is_iterable_train_dataloader else ''
             self.main_progress_bar.set_description(desc)
 

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -47,7 +47,7 @@ class TrainerTrainLoopMixin(object):
 
             # reset progress bar
             self.main_progress_bar.reset(nb_iterations)
-            desc = f'Epoch {epoch_nb}' if not self.is_iterable_train_dataloader else ''
+            desc = f'Epoch {epoch_nb + 1}' if not self.is_iterable_train_dataloader else ''
             self.main_progress_bar.set_description(desc)
 
             # changing gradient according accumulation_scheduler

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -293,7 +293,6 @@ class Trainer(TrainerIOMixin,
         """
         tqdm_dict = {
             'loss': '{0:.3f}'.format(self.avg_loss),
-            'epoch': '{}'.format(self.current_epoch),
             'batch_nb': '{}'.format(self.batch_nb),
         }
 
@@ -426,15 +425,8 @@ class Trainer(TrainerIOMixin,
         # restore training and model before hpc call
         self.restore_weights(model)
 
-        # progress bar init
-        if self.show_progress_bar:
-            self.progress_bar = tqdm.tqdm(0, position=self.process_position)
-
         # when testing requested only run test and return
         if self.testing:
-            if self.show_progress_bar:
-                self.progress_bar.reset(self.nb_test_batches)
-
             self.run_evaluation(test=True)
             return
 
@@ -442,11 +434,24 @@ class Trainer(TrainerIOMixin,
         # to make sure program won't crash during val
         ref_model.on_sanity_check_start()
         if self.get_val_dataloaders() is not None and self.nb_sanity_val_steps > 0:
-            # reset progress_bar limit for sanity check
-            if self.show_progress_bar:
-                self.progress_bar.reset(self.nb_sanity_val_steps)
+            # init progress bars for validation sanity check
+            pbar = tqdm.tqdm(desc='Validation sanity check', total=self.nb_sanity_val_steps,
+                             leave=False, position=2 * self.process_position,
+                             disable=not self.show_progress_bar)
+            self.main_progress_bar = pbar
+            # dummy validation progress bar
+            self.val_progress_bar = tqdm.tqdm(disable=True)
 
             self.evaluate(model, self.get_val_dataloaders(), self.nb_sanity_val_steps, self.testing)
+
+            # close progress bars
+            self.main_progress_bar.close()
+            self.val_progress_bar.close()
+
+        # init progress bar
+        pbar = tqdm.tqdm(leave=True, position=2 * self.process_position,
+                         disable=not self.show_progress_bar)
+        self.main_progress_bar = pbar
 
         # clear cache before training
         if self.on_gpu:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -437,7 +437,7 @@ class Trainer(TrainerIOMixin,
             # init progress bars for validation sanity check
             pbar = tqdm.tqdm(desc='Validation sanity check', total=self.nb_sanity_val_steps,
                              leave=False, position=2 * self.process_position,
-                             disable=not self.show_progress_bar)
+                             disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch')
             self.main_progress_bar = pbar
             # dummy validation progress bar
             self.val_progress_bar = tqdm.tqdm(disable=True)
@@ -450,7 +450,7 @@ class Trainer(TrainerIOMixin,
 
         # init progress bar
         pbar = tqdm.tqdm(leave=True, position=2 * self.process_position,
-                         disable=not self.show_progress_bar)
+                         disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch')
         self.main_progress_bar = pbar
 
         # clear cache before training


### PR DESCRIPTION
Resolves #420 and related to #425. Now we have only one progress bar and this PR adds some more.  The main idea is to have one main progress bar with length equal to the sum of train and val batches and one progress bar for validation step which pops up only when validating. Moreover, progress bars for validation sanity check and for testing are improved. New progress bars looks as follows:
Validation sanity check:
```
Validation sanity check:  60%|██████████████████████████████████                       | 3/5 [00:01<00:01,  2.00batch/s]
```
Training:
```
Epoch 1:  15%|█████                                   | 3/20 [00:01<00:08,  1.94batch/s, batch_nb=2, loss=0.098, v_nb=0]
```
Validating:
```
Epoch 1:  85%|███████████████████████████████        | 17/20 [00:08<00:01,  2.00batch/s, batch_nb=9, loss=0.183, v_nb=0]
Validating:  40%|████████████████████████████                                          | 2/5 [00:01<00:01,  2.00batch/s]
```
Testing:
```
Testing: 100%|█████████████████████████████████████████████████████████████████████████| 5/5 [00:02<00:00,  1.99batch/s]
```

Some minor changes:
- `epoch_nb` has been removed from `tqdm_metrics` and is used in the main progress bar title instead. 
- `nb_iterations` for iterable datasets has been changed from `inf` to `None` (tqdm doesn't work when `total=inf`).
- `nb_iterations` for fast_dev_run has been changed from 1 to 2 since there are one training iteration and one validating iteration.
- `tqdm_metrics` are updated each iteration, not only when `(batch_nb + 1) % accumulate_grad_batches == 0`.

To test new progress bars you can run the following code:
```
from time import sleep
import torch
from torch.utils.data import DataLoader, Dataset

import pytorch_lightning as pl


class DummyDataset(Dataset):
    def __init__(self, n):
        super().__init__()
        self.n = n

    def __len__(self):
        return self.n

    def __getitem__(self, idx):
        return torch.rand(10)


sleep_time = 0.5
class CoolSystem(pl.LightningModule):
    def __init__(self):
        super(CoolSystem, self).__init__()
        self.layer = torch.nn.Linear(10, 10)

    def forward(self, x):
        return self.layer(x)

    def training_step(self, batch, batch_nb):
        sleep(sleep_time)
        return {'loss': torch.mean(self.forward(batch) ** 2)}

    def validation_step(self, batch, batch_nb):
        sleep(sleep_time)
        return {}

    def validation_end(self, outputs):
        return {}

    def test_step(self, batch, batch_nb):
        sleep(sleep_time)
        return {}

    def test_end(self, outputs):
        return {}

    def configure_optimizers(self):
        return [torch.optim.Adam(self.layer.parameters())]

    @pl.data_loader
    def train_dataloader(self):
        return DataLoader(DummyDataset(10), batch_size=1)

    @pl.data_loader
    def val_dataloader(self):
        return DataLoader(DummyDataset(5), batch_size=1)

    @pl.data_loader
    def test_dataloader(self):
        return DataLoader(DummyDataset(5), batch_size=1)

model = CoolSystem()
trainer = pl.Trainer(weights_summary=None, nb_sanity_val_steps=5, early_stop_callback=False,
                     checkpoint_callback=False, val_percent_check=1.0, val_check_interval=0.5,
                     check_val_every_n_epoch=1, accumulate_grad_batches=1, max_nb_epochs=2)
trainer.fit(model)
trainer.test()

print()
print()

model = CoolSystem()
trainer = pl.Trainer(weights_summary=None, nb_sanity_val_steps=5, early_stop_callback=False,
                     checkpoint_callback=False, val_percent_check=1.0, val_check_interval=0.5,
                     check_val_every_n_epoch=1, accumulate_grad_batches=1, max_nb_epochs=2,
                     fast_dev_run=True)
trainer.fit(model)
trainer.test()

print()
print()

model = CoolSystem()
trainer = pl.Trainer(weights_summary=None, nb_sanity_val_steps=0, early_stop_callback=False,
                     checkpoint_callback=False, val_percent_check=1.0, val_check_interval=0.5,
                     check_val_every_n_epoch=1, accumulate_grad_batches=3, max_nb_epochs=2)
trainer.fit(model)
trainer.test()

print()
print()

model = CoolSystem()
trainer = pl.Trainer(weights_summary=None, nb_sanity_val_steps=5, early_stop_callback=False,
                     checkpoint_callback=False, val_percent_check=1.0, val_check_interval=0.5,
                     check_val_every_n_epoch=1, accumulate_grad_batches=1, max_nb_epochs=2)
trainer.test(model)

print()
print('show_progress_bar=False')
print()

model = CoolSystem()
trainer = pl.Trainer(weights_summary=None, nb_sanity_val_steps=5, early_stop_callback=False,
                     checkpoint_callback=False, val_percent_check=1.0, val_check_interval=0.5,
                     check_val_every_n_epoch=1, accumulate_grad_batches=1, max_nb_epochs=2,
                     show_progress_bar=False)
trainer.fit(model)
trainer.test()
```
