### PR TITLE
Fix min_max gpu memory logging bug

### DIFF
--- a/pytorch_lightning/root_module/memory.py
+++ b/pytorch_lightning/root_module/memory.py
@@ -226,7 +226,7 @@ def get_gpu_memory_map():
         capture_output=True,
         check=True)
     # Convert lines into a dictionary
-    gpu_memory = [int(x) for x in result.stdout.strip().split(os.sep)]
+    gpu_memory = [int(x) for x in result.stdout.strip().split(os.linesep)]
     gpu_memory_map = {f'gpu_{index}': memory for index, memory in enumerate(gpu_memory)}
     return gpu_memory_map
 

--- a/pytorch_lightning/root_module/memory.py
+++ b/pytorch_lightning/root_module/memory.py
@@ -3,6 +3,7 @@ Generates a summary of a model's layers and dimensionality
 '''
 
 import gc
+import os
 import subprocess
 
 import numpy as np
@@ -225,7 +226,7 @@ def get_gpu_memory_map():
         capture_output=True,
         check=True)
     # Convert lines into a dictionary
-    gpu_memory = [int(x) for x in result.stdout.strip().split('\n')]
+    gpu_memory = [int(x) for x in result.stdout.strip().split(os.sep)]
     gpu_memory_map = {f'gpu_{index}': memory for index, memory in enumerate(gpu_memory)}
     return gpu_memory_map
 

--- a/pytorch_lightning/root_module/memory.py
+++ b/pytorch_lightning/root_module/memory.py
@@ -202,7 +202,7 @@ def get_memory_profile(mode):
         min_k = None
         max_mem = 0
         max_k = None
-        for k, v in memory_map:
+        for k, v in memory_map.items():
             if v > max_mem:
                 max_mem = v
                 max_k = k

--- a/pytorch_lightning/root_module/memory.py
+++ b/pytorch_lightning/root_module/memory.py
@@ -224,13 +224,17 @@ def get_gpu_memory_map():
         Keys are device ids as integers.
         Values are memory usage as integers in MB.
     """
-    result = subprocess.check_output(
+    result = subprocess.run(
         [
-            'nvidia-smi', '--query-gpu=memory.used',
-            '--format=csv,nounits,noheader'
-        ], encoding='utf-8')
+            'nvidia-smi',
+            '--query-gpu=memory.used',
+            '--format=csv,nounits,noheader',
+        ],
+        encoding='utf-8',
+        capture_output=True,
+        check=True)
     # Convert lines into a dictionary
-    gpu_memory = [int(x) for x in result.strip().split('\n')]
+    gpu_memory = [int(x) for x in result.stdout.strip().split('\n')]
     gpu_memory_map = {}
     for k, v in zip(range(len(gpu_memory)), gpu_memory):
         k = f'gpu_{k}'

--- a/pytorch_lightning/root_module/memory.py
+++ b/pytorch_lightning/root_module/memory.py
@@ -235,10 +235,7 @@ def get_gpu_memory_map():
         check=True)
     # Convert lines into a dictionary
     gpu_memory = [int(x) for x in result.stdout.strip().split('\n')]
-    gpu_memory_map = {}
-    for k, v in zip(range(len(gpu_memory)), gpu_memory):
-        k = f'gpu_{k}'
-        gpu_memory_map[k] = v
+    gpu_memory_map = {f'gpu_{index}': utilization for index, utilization in enumerate(gpu_memory)}
     return gpu_memory_map
 
 

--- a/pytorch_lightning/root_module/memory.py
+++ b/pytorch_lightning/root_module/memory.py
@@ -198,19 +198,10 @@ def get_memory_profile(mode):
     memory_map = get_gpu_memory_map()
 
     if mode == 'min_max':
-        min_mem = 1000000
-        min_k = None
-        max_mem = 0
-        max_k = None
-        for k, v in memory_map.items():
-            if v > max_mem:
-                max_mem = v
-                max_k = k
-            if v < min_mem:
-                min_mem = v
-                min_k = k
+        min_index, min_memory = min(memory_map.items(), key=lambda item: item[1])
+        max_index, max_memory = max(memory_map.items(), key=lambda item: item[1])
 
-        memory_map = {min_k: min_mem, max_k: max_mem}
+        memory_map = {min_index: min_memory, max_index: max_memory}
 
     return memory_map
 
@@ -235,7 +226,7 @@ def get_gpu_memory_map():
         check=True)
     # Convert lines into a dictionary
     gpu_memory = [int(x) for x in result.stdout.strip().split('\n')]
-    gpu_memory_map = {f'gpu_{index}': utilization for index, utilization in enumerate(gpu_memory)}
+    gpu_memory_map = {f'gpu_{index}': memory for index, memory in enumerate(gpu_memory)}
     return gpu_memory_map
 
 

--- a/tests/test_gpu_models.py
+++ b/tests/test_gpu_models.py
@@ -224,7 +224,7 @@ def test_multi_gpu_model_dp():
     testing_utils.run_gpu_model_test(trainer_options, model, hparams)
 
     # test memory helper functions
-    memory.get_gpu_memory_map()
+    memory.get_memory_profile('min_max')
 
 
 def test_ddp_sampler_error():


### PR DESCRIPTION
## Before submitting

- Was this discussed/approved via a Github issue? Yes. #452 
- Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)? Yes.
- Did you make sure to update the docs?  N/A
- Did you write any new necessary tests? Yes.

## What does this PR do?
Fixes #452 

Additionally, this PR updates & simplifies some code.
1. Use `subprocess.run` as officially recommended by python docs (refer to https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module)
2. Clean up code around gpu memory function.
3. Increase test coverage by adding test for get_memory_profile.

## Did you have fun?
Yes :)
