### PR TITLE
drop hard-coded test-tube

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,15 +57,15 @@ install:
 script:
   # integration
   - tox --sitepackages
-  - pip install --editable .
+  # try install and run
+  - virtualenv vEnv ; source vEnv/bin/activate ; pip install .
+  - cd .. ; python -c "import pytorch_lightning as tl ; print(tl.__version__)"
 
 after_success:
   - coverage report
   # disable auto coverage bc it isn't accurate since it misses gpu code.
   # to get coverage, run local and push results
   # - codecov
-  - virtualenv vEnv ; source vEnv/bin/activate ; python setup.py install
-  - cd .. ; python -c "import pytorch_ligntning as tl ; print(tl.__version__)"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,8 @@ after_success:
   # disable auto coverage bc it isn't accurate since it misses gpu code.
   # to get coverage, run local and push results
   # - codecov
+  - virtualenv vEnv ; source vEnv/bin/activate ; python setup.py install
+  - cd .. ; python -c "import pytorch_ligntning as tl ; print(tl.__version__)"
 
 notifications:
   email: false

--- a/pytorch_lightning/logging/comet_logger.py
+++ b/pytorch_lightning/logging/comet_logger.py
@@ -1,12 +1,14 @@
 try:
     from comet_ml import Experiment as CometExperiment
 except ImportError:
-    raise ImportError('Missing comet_ml package.')
+    raise ImportError('You want to use `comet_ml` logger which is not installed yet,'
+                      ' please install it e.g. `pip install comet_ml`.')
 
 from .base import LightningLoggerBase, rank_zero_only
 
 
 class CometLogger(LightningLoggerBase):
+
     def __init__(self, *args, **kwargs):
         super(CometLogger, self).__init__()
         self.experiment = CometExperiment(*args, **kwargs)

--- a/pytorch_lightning/logging/mlflow_logger.py
+++ b/pytorch_lightning/logging/mlflow_logger.py
@@ -4,7 +4,8 @@ from time import time
 try:
     import mlflow
 except ImportError:
-    raise ImportError('Missing mlflow package.')
+    raise ImportError('You want to use `mlflow` logger which is not installed yet,'
+                      ' please install it e.g. `pip install mlflow`.')
 
 from .base import LightningLoggerBase, rank_zero_only
 
@@ -12,6 +13,7 @@ logger = getLogger(__name__)
 
 
 class MLFlowLogger(LightningLoggerBase):
+
     def __init__(self, experiment_name, tracking_uri=None, tags=None):
         super().__init__()
         self.experiment = mlflow.tracking.MlflowClient(tracking_uri)

--- a/pytorch_lightning/logging/test_tube_logger.py
+++ b/pytorch_lightning/logging/test_tube_logger.py
@@ -1,7 +1,8 @@
 try:
     from test_tube import Experiment
 except ImportError:
-    raise ImportError('Missing test-tube package.')
+    raise ImportError('You want to use `test-tube` logger which is not installed yet,'
+                      ' please install it e.g. `pip install test-tube`.')
 
 from .base import LightningLoggerBase, rank_zero_only
 

--- a/pytorch_lightning/trainer/callback_config_mixin.py
+++ b/pytorch_lightning/trainer/callback_config_mixin.py
@@ -59,7 +59,7 @@ class TrainerCallbackConfigMixin(object):
             self.enable_early_stop = True
 
         # default logger
-        if logger == 'test-tube':
+        if isinstance(logger, str) and logger == 'test-tube':
             try:
                 from pytorch_lightning.logging import TestTubeLogger
                 logger = TestTubeLogger(
@@ -72,8 +72,8 @@ class TrainerCallbackConfigMixin(object):
                 logger = None
 
         # configure logger
-        if logger:
+        if isinstance(logger, object):
             self.logger = logger
             self.logger.rank = 0
-        elif logger is False:
+        else:
             self.logger = None

--- a/pytorch_lightning/trainer/callback_config_mixin.py
+++ b/pytorch_lightning/trainer/callback_config_mixin.py
@@ -2,6 +2,7 @@ import os
 import logging
 
 from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
+from pytorch_lightning.logging.base import LightningLoggerBase
 
 
 class TrainerCallbackConfigMixin(object):
@@ -72,7 +73,7 @@ class TrainerCallbackConfigMixin(object):
                 logger = None
 
         # configure logger
-        if isinstance(logger, object):
+        if isinstance(logger, LightningLoggerBase):
             self.logger = logger
             self.logger.rank = 0
         else:

--- a/pytorch_lightning/trainer/callback_config_mixin.py
+++ b/pytorch_lightning/trainer/callback_config_mixin.py
@@ -1,10 +1,11 @@
 import os
+import logging
 
 from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
-from pytorch_lightning.logging import TestTubeLogger
 
 
 class TrainerCallbackConfigMixin(object):
+
     def configure_checkpoint_callback(self):
         """
         Weight path set in this priority:
@@ -41,7 +42,7 @@ class TrainerCallbackConfigMixin(object):
         if self.weights_save_path is None:
             self.weights_save_path = self.default_save_path
 
-    def configure_early_stopping(self, early_stop_callback, logger):
+    def configure_early_stopping(self, early_stop_callback, logger='test-tube'):
         if early_stop_callback is True:
             self.early_stop_callback = EarlyStopping(
                 monitor='val_loss',
@@ -57,17 +58,22 @@ class TrainerCallbackConfigMixin(object):
             self.early_stop_callback = early_stop_callback
             self.enable_early_stop = True
 
+        # default logger
+        if logger == 'test-tube':
+            try:
+                from pytorch_lightning.logging import TestTubeLogger
+                logger = TestTubeLogger(
+                    save_dir=self.default_save_path,
+                    version=self.slurm_job_id,
+                    name='lightning_logs'
+                )
+            except:
+                logging.exception('Fail to create Test-tube default logger.')
+                logger = None
+
         # configure logger
-        if logger is True:
-            # default logger
-            self.logger = TestTubeLogger(
-                save_dir=self.default_save_path,
-                version=self.slurm_job_id,
-                name='lightning_logs'
-            )
+        if logger:
+            self.logger = logger
             self.logger.rank = 0
         elif logger is False:
             self.logger = None
-        else:
-            self.logger = logger
-            self.logger.rank = 0

--- a/pytorch_lightning/trainer/callback_config_mixin.py
+++ b/pytorch_lightning/trainer/callback_config_mixin.py
@@ -68,7 +68,7 @@ class TrainerCallbackConfigMixin(object):
                     version=self.slurm_job_id,
                     name='lightning_logs'
                 )
-            except:
+            except Exception:
                 logging.exception('Fail to create Test-tube default logger.')
                 logger = None
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -50,7 +50,7 @@ class Trainer(TrainerIOMixin,
               TrainerModelHooksMixin):
 
     def __init__(self,
-                 logger=True,
+                 logger='test-tube',
                  checkpoint_callback=True,
                  early_stop_callback=True,
                  default_save_path=None,


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes #469.

* the `test-tube` is default logger but it does not crash lightning if a user does not have it...
* also added sample installation & run to CI (Travis)