### PR TITLE
Remove erroneous comma in logging call

### DIFF
--- a/pytorch_lightning/callbacks/pt_callbacks.py
+++ b/pytorch_lightning/callbacks/pt_callbacks.py
@@ -253,7 +253,7 @@ class ModelCheckpoint(Callback):
                         if self.verbose > 0:
                             logging.info(
                                 f'\nEpoch {epoch + 1:05d}: {self.monitor} improved'
-                                f' from {self.best:0.5f} to {current:0.5f},',
+                                f' from {self.best:0.5f} to {current:0.5f},'
                                 f' saving model to {filepath}')
                         self.best = current
                         self.save_model(filepath, overwrite=True)


### PR DESCRIPTION
Raises warning. Introduced in 5a9afb11cc270cae5e59048dd78a894e90170ab3