### PR TITLE
Add circle CI for building PyTorch 1.1/1.2/1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
       name: Install Dependences
       command: |
         # PyPI
-        pip install $TORCH_VERSION
+        pip install "$TORCH_VERSION" --user
         pip install -r requirements.txt --user
 
   tests_format: &tests_format
@@ -19,7 +19,7 @@ references:
      name: Tests and formating
      command: |
        sudo pip install pytest pytest-cov pytest-flake8
-       pip install -r tests/requiremensts.txt
+       pip install -r ./tests/requirements.txt
 
        python --version ; pip --version ; pip list
        py.test pytorch_lightning tests pl_examples -v --doctest-modules --junitxml=test-reports/pytest_junit.xml --flake8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2.0
+
+references:
+
+  install_deps: &install_deps
+    run:
+      name: Install Dependences
+      command: |
+        # PyPI
+        pip install $TORCH_VERSION
+        pip install -r requirements.txt --user
+
+  tests_format: &tests_format
+   run:
+     name: Tests and formating
+     command: |
+       sudo pip install pytest pytest-cov pytest-flake8
+       pip install -r tests/requiremensts.txt
+
+       python --version ; pip --version ; pip list
+       py.test pytorch_lightning tests pl_examples -v --doctest-modules --junitxml=test-reports/pytest_junit.xml --flake8
+
+jobs:
+
+  PyTorch:
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      - TORCH_VERSION: "torch"
+    steps: &steps
+      - checkout
+
+      - *install_deps
+      - *tests_format
+
+      - store_test_results:
+          path: test-reports
+      - store_artifacts:
+          path: test-reports
+
+  PyTorch-v1.1:
+    docker:
+      - image: circleci/python:3.6
+    environment:
+      - TORCH_VERSION: "torch>=1.1, <1.2"
+    steps: *steps
+
+  PyTorch-v1.2:
+    docker:
+      - image: circleci/python:3.6
+    environment:
+      - TORCH_VERSION: "torch>=1.2, <1.3"
+    steps: *steps
+
+  PyTorch-v1.3:
+    docker:
+      - image: circleci/python:3.6
+    environment:
+      - TORCH_VERSION: "torch>=1.3, <1.4"
+    steps: *steps
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - PyTorch-v1.1
+      - PyTorch-v1.2
+      - PyTorch-v1.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,13 @@ references:
         # PyPI
         pip install "$TORCH_VERSION" --user
         pip install -r requirements.txt --user
+        sudo pip install pytest pytest-cov pytest-flake8
+        pip install -r ./tests/requirements.txt --user
 
   tests_format: &tests_format
    run:
      name: Tests and formating
      command: |
-       sudo pip install pytest pytest-cov pytest-flake8
-       pip install -r ./tests/requirements.txt
-
        python --version ; pip --version ; pip list
        py.test pytorch_lightning tests pl_examples -v --doctest-modules --junitxml=test-reports/pytest_junit.xml --flake8
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,6 +37,7 @@ exclude *.yml
 
 prune .git
 prune .github
+prune .circleci
 prune notebook*
 prune temp*
 prune test*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 scikit-learn==0.20.2
 tqdm==4.35.0
 numpy==1.16.4
-torch>=1.2.0
+torch>=1.1
 torchvision>=0.3.0
 pandas>=0.20.3
 test-tube>=0.6.9


### PR DESCRIPTION
Adding one more CI to have built with all major PyTorch releases. Adding this to existing Travis will make each build too long since Travis and CircleCI will run in parallel...

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes #462. Reaction to #491.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.