### PR TITLE
Fix typo in LightningModule->Methods in the docs.

### DIFF
--- a/docs/LightningModule/methods.md
+++ b/docs/LightningModule/methods.md
@@ -9,7 +9,7 @@ model.freeze()
 ```
 
 ---    
-### load_from_metrics
+### load_from_checkpoint
 This is the easiest/fastest way which loads hyperparameters and weights from a checkpoint,
 such as the one saved by the `ModelCheckpoint` callback
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes a typo in the docs. 

