### PR TITLE
Fix incorrect handling of on_batch_end edge cases in run_training_batch

### DIFF
--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -155,7 +155,7 @@ class TrainerTrainLoopMixin(object):
         all_log_metrics = []
 
         if batch is None:
-            return 0, grad_norm_dic, all_log_metrics
+            return 0, grad_norm_dic, {}
 
         # hook
         if self.is_function_implemented('on_batch_start'):
@@ -163,7 +163,7 @@ class TrainerTrainLoopMixin(object):
             response = model_ref.on_batch_start(batch)
 
             if response == -1:
-                return -1, grad_norm_dic, all_log_metrics
+                return -1, grad_norm_dic, {}
 
         splits = [batch]
         if self.truncated_bptt_steps is not None:

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -163,7 +163,7 @@ class TrainerTrainLoopMixin(object):
             response = model_ref.on_batch_start(batch)
 
             if response == -1:
-                return -1, grad_norm_dic
+                return -1, grad_norm_dic, all_log_metrics
 
         splits = [batch]
         if self.truncated_bptt_steps is not None:

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -155,7 +155,7 @@ class TrainerTrainLoopMixin(object):
         all_log_metrics = []
 
         if batch is None:
-            return 0, grad_norm_dic
+            return 0, grad_norm_dic, all_log_metrics
 
         # hook
         if self.is_function_implemented('on_batch_start'):


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
This fixes a bug 

`ValueError: not enough values to unpack (expected 3, got 2)` 

When trying to return -1 to exit early during `on_batch_start`, and also when the batch is empty.

For future work, we should have a test for this regression. 

https://github.com/williamFalcon/pytorch-lightning/blob/8f8cea1c5759524c6fc2eb33b972bba64e5ce0f4/pytorch_lightning/trainer/train_loop_mixin.py#L100

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
