### PR TITLE
Avoid race condition in creating checkpoint directories

### DIFF
--- a/pytorch_lightning/callbacks/pt_callbacks.py
+++ b/pytorch_lightning/callbacks/pt_callbacks.py
@@ -198,8 +198,7 @@ class ModelCheckpoint(Callback):
         self.monitor = monitor
         self.verbose = verbose
         self.filepath = filepath
-        if not os.path.exists(filepath):
-            os.makedirs(filepath, exist_ok=True)
+        os.makedirs(filepath, exist_ok=True)
         self.save_top_k = save_top_k
         self.save_weights_only = save_weights_only
         self.period = period

--- a/pytorch_lightning/callbacks/pt_callbacks.py
+++ b/pytorch_lightning/callbacks/pt_callbacks.py
@@ -199,7 +199,7 @@ class ModelCheckpoint(Callback):
         self.verbose = verbose
         self.filepath = filepath
         if not os.path.exists(filepath):
-            os.makedirs(filepath)
+            os.makedirs(filepath, exist_ok=True)
         self.save_top_k = save_top_k
         self.save_weights_only = save_weights_only
         self.period = period


### PR DESCRIPTION
In multi-GPU training, several processes run the code that creates checkpoint dirs. This fix avoids a probably rare situation (but it happened to me) where another process created a dir between the `exists` check and the `makedirs` call.

## What does this PR do?
Fixes #529.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Sure :)
