### PR TITLE
Write progress bar to stdout

### DIFF
--- a/pytorch_lightning/trainer/evaluation_loop_mixin.py
+++ b/pytorch_lightning/trainer/evaluation_loop_mixin.py
@@ -1,4 +1,5 @@
 import torch
+import sys
 import tqdm
 
 from pytorch_lightning.utilities.debugging import MisconfigurationException
@@ -120,7 +121,7 @@ class TrainerEvaluationLoopMixin(object):
             desc = 'Testing' if test else 'Validating'
             pbar = tqdm.tqdm(desc=desc, total=max_batches, leave=test, position=position,
                              disable=not self.show_progress_bar, dynamic_ncols=True,
-                             unit='batch')
+                             unit='batch', file=sys.stdout)
             setattr(self, f'{"test" if test else "val"}_progress_bar', pbar)
 
             # run evaluation

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -3,6 +3,7 @@ The trainer handles all the logic for running a val loop, training loop, distrib
 """
 
 import os
+import sys
 import warnings
 import logging
 
@@ -460,7 +461,8 @@ class Trainer(TrainerIOMixin,
 
         # init progress bar
         pbar = tqdm.tqdm(leave=True, position=2 * self.process_position,
-                         disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch')
+                         disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch',
+                         file=sys.stdout)
         self.main_progress_bar = pbar
 
         # clear cache before training


### PR DESCRIPTION
By default tqdm writes the progress bar to stderr. This PR changes the default to write to stdout, which is more sensible.