### PR TITLE
Copy batch for local forward

### DIFF
--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -290,7 +290,7 @@ class TrainerTrainLoopMixin(object):
             gpu_id = 0
             if type(self.data_parallel_device_ids) is list:
                 gpu_id = self.data_parallel_device_ids[0]
-            batch = self.transfer_batch_to_gpu(batch, gpu_id)
+            batch = self.transfer_batch_to_gpu(batch.copy(), gpu_id)
             args[0] = batch
             output = self.model.training_step(*args)
 


### PR DESCRIPTION
When truncated_bptt > 1 and using a single GPU without dp/ddp. There's a bug where the batch split isn't freed after training_step. This PR solves the issue by only passing in a copy of the batch to training_step, which is probably how it's done within the internals of dp/dpp.