### PR TITLE
Remove unneeded filename print in callback

### DIFF
--- a/pytorch_lightning/callbacks/pt_callbacks.py
+++ b/pytorch_lightning/callbacks/pt_callbacks.py
@@ -276,8 +276,6 @@ class ModelCheckpoint(Callback):
                 filepath = f'{self.filepath}/{self.prefix}_ckpt_epoch_{epoch}_v{version_cnt}.ckpt'
                 version_cnt += 1
 
-            print(filepath)
-
             if self.save_top_k != -1:
                 current = logs.get(self.monitor)
 


### PR DESCRIPTION
This save model file path is printed at the end of each epoch. Is it supposed to be here, or left over from some debugging? 