### PR TITLE
Move model to cuda before creating optimizer

### DIFF
--- a/pytorch_lightning/trainer/dp_mixin.py
+++ b/pytorch_lightning/trainer/dp_mixin.py
@@ -63,11 +63,11 @@ class TrainerDPMixin(object):
         return batch
 
     def single_gpu_train(self, model):
+        model.cuda(self.root_gpu)
+
         # CHOOSE OPTIMIZER
         # allow for lr schedulers as well
         self.optimizers, self.lr_schedulers = self.init_optimizers(model.configure_optimizers())
-
-        model.cuda(self.root_gpu)
 
         if self.use_amp:
             # An example


### PR DESCRIPTION
This is a bug fix.

How to reproduce: try using Adagrad with cuda. Optimizers are created before the model is on cuda, and so the optimizer's accumulator is created on CPU. That causes an exception when gpu grads are handled in Adagrad.step()

Adam works without this fix. I'm not sure why