### PR TITLE
Dp default

### DIFF
--- a/pytorch_lightning/trainer/ddp_mixin.py
+++ b/pytorch_lightning/trainer/ddp_mixin.py
@@ -45,9 +45,12 @@ class TrainerDDPMixin(object):
                 self.use_ddp2 = distributed_backend == 'ddp2'
 
             elif distributed_backend is None:
-                m = 'When using multiple GPUs set ' \
-                    'Trainer(distributed_backend=dp) (or ddp)'
-                raise MisconfigurationException(m)
+                m = 'You requested multiple GPUs but did not specify a backend' \
+                    'Trainer(distributed_backend=dp) (or ddp, ddp2)' \
+                    'Setting distributed_backend=dp for you'
+                self.use_dp = True
+                self.use_ddp = False
+                self.use_ddp2 = False
 
         # throw error to force user ddp or ddp2 choice
         if nb_gpu_nodes > 1 and not (self.use_ddp2 or self.use_ddp):  # pragma: no cover

--- a/pytorch_lightning/trainer/ddp_mixin.py
+++ b/pytorch_lightning/trainer/ddp_mixin.py
@@ -48,6 +48,7 @@ class TrainerDDPMixin(object):
                 m = 'You requested multiple GPUs but did not specify a backend' \
                     'Trainer(distributed_backend=dp) (or ddp, ddp2)' \
                     'Setting distributed_backend=dp for you'
+                warnings.warn(m)
                 self.use_dp = True
                 self.use_ddp = False
                 self.use_ddp2 = False

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 #
 #  - check-manifest
 #     confirm items checked into vcs are in your segdist
-#  - python setup.py check 
+#  - python setup.py check
 #     confirm required package meta-data in setup.py
 #  - readme_renderer (when using a ReStructuredText README)
 #     confirms your long_description will render correctly on PyPI.
@@ -37,8 +37,8 @@ commands =
     pip list
     check-manifest --ignore requirements-ci.txt
     python setup.py check --metadata --strict
-    coverage run --source pytorch_lightning -m py.test pytorch_lightning tests pl_examples -v --doctest-modules
     flake8 .
+    coverage run --source pytorch_lightning -m py.test pytorch_lightning tests pl_examples -v --doctest-modules
     python setup.py sdist
     twine check dist/*
 


### PR DESCRIPTION
Set backend to dp by default when no backend specified.

Annoying for users  who blindly want to use multiple GPUs to have to deal with choosing a backend.

There might even be an argument for not throwing a warning? @neggert @Borda @jeffling 