### PR TITLE
model summary print instead of logging

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1022,7 +1022,7 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
 
     def summarize(self, mode):
         model_summary = ModelSummary(self, mode=mode)
-        logging.info(model_summary)
+        print(model_summary)
 
     def freeze(self):
         """Freeze all params for inference


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? 
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)? 
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes #518. Model summary printing should be controlled by trainer argument `weights_summary` (full, top, None), not logging level. Using the print function should be ok in this case.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
