### PR TITLE
Error message for multiple optimizers

### DIFF
--- a/pytorch_lightning/trainer/model_hooks_mixin.py
+++ b/pytorch_lightning/trainer/model_hooks_mixin.py
@@ -1,3 +1,4 @@
+import inspect
 from pytorch_lightning.core.lightning import LightningModule
 
 
@@ -15,3 +16,8 @@ class TrainerModelHooksMixin(object):
         # when code pointers are different, it was overriden
         is_overriden = getattr(model, f_name).__code__ is not getattr(super_object, f_name).__code__
         return is_overriden
+
+    def has_arg(self, f_name, arg_name):
+        model = self.get_model()
+        f_op = getattr(model, f_name, None)
+        return arg_name in inspect.signature(f_op).parameters

--- a/pytorch_lightning/trainer/train_loop_mixin.py
+++ b/pytorch_lightning/trainer/train_loop_mixin.py
@@ -149,6 +149,7 @@ When this flag is enabled each batch is split into sequences of size truncated_b
 
 """
 
+import inspect
 import numpy as np
 import tqdm
 
@@ -423,10 +424,16 @@ class TrainerTrainLoopMixin(object):
         # ---------------
         # FORWARD
         # ---------------
-        # enable not needing to add opt_idx to training_step
+        # training_step has an optional optimizer_idx argument
         args = [batch, batch_nb]
         if len(self.optimizers) > 1:
-            args.append(opt_idx)
+            if self.has_arg('training_step', 'optimizer_idx'):
+                args.append(opt_idx)
+            else:
+                raise ValueError(
+                    f'Your LightningModule defines {len(self.optimizers)} optimizers but '
+                    f'training_step is missing the "optimizer_idx" argument.'
+                )
 
         # pass hiddens if using tbptt
         if self.truncated_bptt_steps is not None:


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
**Attempt to address #497.
It uses the inspect module. Added helper function to hooks mixin. 
Should the names training_step/optimizer_idx be hardcoded as string? 
If it is good like this, should we consider a check for other optimal arguments in LightningModule, e.g., dataset_idx?**

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
yes
