### PR TITLE
Fix CometML tests

### DIFF
--- a/pytorch_lightning/logging/comet.py
+++ b/pytorch_lightning/logging/comet.py
@@ -167,9 +167,4 @@ class CometLogger(LightningLoggerBase):
 
     @property
     def version(self):
-        if self.project_name and self.rest_api_key:
-            # Determines the number of experiments in this project, and returns the next integer as the version number
-            num_exps = len(self.comet_api.get_experiments(self.workspace, self.project_name))
-            return num_exps + 1
-        else:
-            return None
+        return self.experiment.id

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -106,8 +106,14 @@ def test_mlflow_pickle(tmpdir):
     trainer2.logger.log_metrics({"acc": 1.0})
 
 
-def test_comet_logger(tmpdir):
+def test_comet_logger(tmpdir, monkeypatch):
     """Verify that basic functionality of Comet.ml logger works."""
+
+    # prevent comet logger from trying to print at exit, since
+    # pytest's stdout/stderr redirection breaks it
+    import atexit
+    monkeypatch.setattr(atexit, "register", lambda _: None)
+
     tutils.reset_seed()
 
     try:
@@ -140,8 +146,14 @@ def test_comet_logger(tmpdir):
     assert result == 1, "Training failed"
 
 
-def test_comet_pickle(tmpdir):
+def test_comet_pickle(tmpdir, monkeypatch):
     """Verify that pickling trainer with comet logger works."""
+
+    # prevent comet logger from trying to print at exit, since
+    # pytest's stdout/stderr redirection breaks it
+    import atexit
+    monkeypatch.setattr(atexit, "register", lambda _: None)
+
     tutils.reset_seed()
 
     try:


### PR DESCRIPTION
In master, the CometML tests print a bunch of nasty warning messages because the `comet_ml` library uses `atexit.register` to print a summary. This conflicts with pytest's redirecting of stdout and stderr. More info here: https://github.com/pytest-dev/pytest/issues/5577. Fixed it by monkeypatching `atexit.register` to do nothing.

While I was in there, I noticed that the `version` property behaves differently than for the other loggers, so I fixed it.