### PR TITLE
prevent Travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,12 @@ script:
   - tox --sitepackages
 
   #- python setup.py install --dry-run --user
-  - virtualenv vEnv & source vEnv/bin/activate
-  - pip install --editable .
-  - cd .. & python -c "import pytorch_lightning ; print(pytorch_lightning.__version__)"
+  - virtualenv vEnv ;
+    source vEnv/bin/activate
+  - pip install --editable . ;
+    cd .. & python -c "import pytorch_lightning ; print(pytorch_lightning.__version__)"
+  - deactivate ;
+    rm -rf vEnv
 
 after_success:
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ before_script:
 script:
   # integration
   - tox --sitepackages
-  - pip install --editable .
-  #- python setup.py install --dry-run --user
+  #- pip install --editable .
+  - python setup.py install --dry-run --user
 
 after_success:
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,11 @@ before_script:
 script:
   # integration
   - tox --sitepackages
-  #- pip install --editable .
-  - python setup.py install --dry-run --user
+
+  #- python setup.py install --dry-run --user
+  - virtualenv vEnv & source vEnv/bin/activate
+  - pip install --editable .
+  - cd .. & python -c "import pytorch_lightning ; print(pytorch_lightning.__version__)"
 
 after_success:
   - coverage report


### PR DESCRIPTION
## What does this PR do?
As it is now the package installed `pip install --editable .` and so it is cached so in future it may (it is probably happening right now as it is referring to failing on actually empty line) interfere... 
This change performs the package installs in clean virtual env which is removed after all.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
