### PR TITLE
Fix GAN training by replacing zero_grad logic

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -752,7 +752,6 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
         else:
             optimizer.step()
 
-
     def tbptt_split_batch(self, batch, split_size):
         """
         Return list of batch splits. Each split will be passed to forward_step to enable truncated

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -704,7 +704,7 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
         :param second_order_closure: closure for second order methods
         :return:
 
-        Calls `.step()` and `.zero_grad` for each optimizer.
+        Calls `.step()` for each optimizer.
         You can override this method to adjust how you do the optimizer step for each optimizer
 
         Called once per optimizer
@@ -714,7 +714,6 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
             # DEFAULT
             def optimizer_step(self, current_epoch, batch_idx, optimizer, optimizer_idx, second_order_closure=None):
                 optimizer.step()
-                optimizer.zero_grad()
 
             # Alternating schedule for optimizer steps (ie: GANs)
             def optimizer_step(self, current_epoch, batch_idx, optimizer, optimizer_idx, second_order_closure=None):
@@ -722,13 +721,11 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
                 if optimizer_idx == 0:
                     if batch_idx % 2 == 0 :
                         optimizer.step()
-                        optimizer.zero_grad()
 
                 # update discriminator opt every 4 steps
                 if optimizer_idx == 1:
                     if batch_idx % 4 == 0 :
                         optimizer.step()
-                        optimizer.zero_grad()
 
                 # ...
                 # add as many optimizers as you want
@@ -748,7 +745,6 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
 
                 # update params
                 optimizer.step()
-                optimizer.zero_grad()
 
         """
         if isinstance(optimizer, torch.optim.LBFGS):
@@ -756,8 +752,6 @@ class LightningModule(GradInformation, ModelIO, ModelHooks):
         else:
             optimizer.step()
 
-        # clear gradients
-        optimizer.zero_grad()
 
     def tbptt_split_batch(self, batch, split_size):
         """

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -493,6 +493,13 @@ class TrainerTrainLoopMixin(ABC):
                     model = self.get_model()
                     model.optimizer_step(self.current_epoch, batch_idx,
                                          optimizer, opt_idx, optimizer_closure)
+                    
+                    # clear all gradients
+                    for optimizer_ in self.optimizers:
+                        optimizer_.zero_grad()
+                        
+                    # or just 
+                    # self.zero_grad()
 
                     # calculate running loss for display
                     self.running_loss.append(self.batch_loss_value)

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -493,12 +493,12 @@ class TrainerTrainLoopMixin(ABC):
                     model = self.get_model()
                     model.optimizer_step(self.current_epoch, batch_idx,
                                          optimizer, opt_idx, optimizer_closure)
-                    
+
                     # clear all gradients
                     for optimizer_ in self.optimizers:
                         optimizer_.zero_grad()
-                        
-                    # or just 
+
+                    # or just
                     # self.zero_grad()
 
                     # calculate running loss for display


### PR DESCRIPTION
Hope this solves the issue https://github.com/williamFalcon/pytorch-lightning/issues/591 without messing with other things. I removed zero_grad logic from optimizer_step to outside since optimizer_step function does not have access to the other optimizers to zero_grad and thought self.zero_grad would not permit calling on_before_zero_grad in the future.
