### PR TITLE
Fix number of total steps shown in progress bar during sanity validation check when number of validation dataloaders >= 2

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -491,8 +491,8 @@ class Trainer(TrainerIOMixin,
         ref_model.on_sanity_check_start()
         if self.get_val_dataloaders() is not None and self.num_sanity_val_steps > 0:
             # init progress bars for validation sanity check
-            pbar = tqdm.tqdm(desc='Validation sanity check', 
-                             total=self.num_sanity_val_steps*len(self.get_val_dataloaders()),
+            pbar = tqdm.tqdm(desc='Validation sanity check',
+                             total=self.num_sanity_val_steps * len(self.get_val_dataloaders()),
                              leave=False, position=2 * self.process_position,
                              disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch')
             self.main_progress_bar = pbar

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -491,7 +491,8 @@ class Trainer(TrainerIOMixin,
         ref_model.on_sanity_check_start()
         if self.get_val_dataloaders() is not None and self.num_sanity_val_steps > 0:
             # init progress bars for validation sanity check
-            pbar = tqdm.tqdm(desc='Validation sanity check', total=self.num_sanity_val_steps*len(self.get_val_dataloaders()),
+            pbar = tqdm.tqdm(desc='Validation sanity check', 
+                             total=self.num_sanity_val_steps*len(self.get_val_dataloaders()),
                              leave=False, position=2 * self.process_position,
                              disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch')
             self.main_progress_bar = pbar

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -491,7 +491,7 @@ class Trainer(TrainerIOMixin,
         ref_model.on_sanity_check_start()
         if self.get_val_dataloaders() is not None and self.num_sanity_val_steps > 0:
             # init progress bars for validation sanity check
-            pbar = tqdm.tqdm(desc='Validation sanity check', total=self.num_sanity_val_steps,
+            pbar = tqdm.tqdm(desc='Validation sanity check', total=self.num_sanity_val_steps*len(self.get_val_dataloaders()),
                              leave=False, position=2 * self.process_position,
                              disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch')
             self.main_progress_bar = pbar


### PR DESCRIPTION
Calculate the adequate number of steps to run during sanity_check.
This fixes the bug when there are two or more validation dataloaders.

- Before: total=self.num_sanity_val_steps
- After: total=self.num_sanity_val_steps*len(self.get_val_dataloaders())

# Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [X] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes #586 .

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
