### PR TITLE
Additional hooks

### DIFF
--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -28,8 +28,24 @@ class ModelHooks(torch.nn.Module):
     def on_sanity_check_start(self):
         """
         Called before starting evaluate
+        .. warning:: will be deprecated.
         :return:
         """
+        pass
+
+    def on_train_start(self):
+        """Called at the beginning of training before sanity check
+        :return:
+        """
+        # do something at the start of training
+        pass
+
+    def on_train_end(self):
+        """
+        Called at the end of training before logger experiment is closed
+        :return:
+        """
+        # do something at the end of training
         pass
 
     def on_batch_start(self, batch):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -489,6 +489,7 @@ class Trainer(TrainerIOMixin,
         # run tiny validation (if validation defined)
         # to make sure program won't crash during val
         ref_model.on_sanity_check_start()
+        ref_model.on_train_start()
         if self.get_val_dataloaders() is not None and self.num_sanity_val_steps > 0:
             # init progress bars for validation sanity check
             pbar = tqdm.tqdm(desc='Validation sanity check', total=self.num_sanity_val_steps,

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -331,6 +331,8 @@ class TrainerTrainLoopMixin(ABC):
 
         self.main_progress_bar.close()
 
+        model.on_train_end()
+
         if self.logger is not None:
             self.logger.finalize("success")
 

--- a/tests/test_restore_models.py
+++ b/tests/test_restore_models.py
@@ -247,7 +247,7 @@ def test_dp_resume(tmpdir):
 
     # new model
     model = LightningTestModel(hparams)
-    model.on_sanity_check_start = assert_good_acc
+    model.on_train_start = assert_good_acc
 
     # fit new model which should load hpc weights
     new_trainer.fit(model)
@@ -311,7 +311,7 @@ def test_cpu_restore_training(tmpdir):
         for dataloader in trainer.get_val_dataloaders():
             tutils.run_prediction(dataloader, trainer.model)
 
-    model.on_sanity_check_start = assert_good_acc
+    model.on_train_start = assert_good_acc
 
     # by calling fit again, we trigger training, loading weights from the cluster
     # and our hook to predict using current model before any more weight updates


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
As discussed in #556 I'd like to propose adding model hooks for training start and end. As I noticed a hook already exists for training start (`on_sanity_check_start`), I basically just renamed to `on_train_start` it as I find it clearer (they still coexist for now). If that is ok with you I could then add deprecation warnings for `on_sanity_check_start`. We could also let it be as it was if it is just me who finds it clearer that way.
I also added `on_train_end` that is executed at the end of the training loop just before logger experiment is closed. It would be a time to log weights, maybe reload best model or anything we could be wanting to do when training ends. I know it is a bit confusing with `training_end` that happens after each batch, but I didn't find a better name yet and I am obviously open to ideas.
I changed tests from `on_sanity_check_start` to `on_train_start` but didn't add any for `on_train_end` as I am not sure what test I could create. 
As for the docs, it seems to me that model hooks are undocumented. I could try to document them as I find them very useful, but I am not sure how docs are written in this project.

I am obviously open to feedback, as this PR is pretty much a personal quality of life improvement, so I am not sure it has many use cases.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Of course !
