### PR TITLE
Make sure train doesn't crash when called at max_epoch

### DIFF
--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -258,6 +258,7 @@ class TrainerTrainLoopMixin(ABC):
         pass
 
     def train(self):
+        model = self.get_model()
         # run all epochs
         for epoch in range(self.current_epoch, self.max_epochs):
             # set seed for distributed sampler (enables shuffling for each epoch)


### PR DESCRIPTION
#598 introduced as subtle bug where `Trainer.train` would crash on an uninitialized variable if the trainer was run after resuming from a checkpoint that was already at `max_epochs`. This PR makes sure we always have a reference to the model, even if the train loop never runs.