### PR TITLE
fix metric name to work with default earlystopping

### DIFF
--- a/pytorch_lightning/core/__init__.py
+++ b/pytorch_lightning/core/__init__.py
@@ -48,8 +48,8 @@ Minimal example
 
         def validation_end(self, outputs):
             # OPTIONAL
-            avg_loss = torch.stack([x['val_loss'] for x in outputs]).mean()
-            return {'avg_val_loss': avg_loss}
+            val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()
+            return {'val_loss': val_loss_mean}
 
         def test_step(self, batch, batch_idx):
             # OPTIONAL
@@ -59,8 +59,8 @@ Minimal example
 
         def test_end(self, outputs):
             # OPTIONAL
-            avg_loss = torch.stack([x['test_loss'] for x in outputs]).mean()
-            return {'avg_test_loss': avg_loss}
+            test_loss_mean = torch.stack([x['test_loss'] for x in outputs]).mean()
+            return {'test_loss': test_loss_mean}
 
         def configure_optimizers(self):
             # REQUIRED


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, **doc improvements**)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  (**doc improvement**)

## What does this PR do?

The documentation is not clear how metrics are consumed by the `Trainer` object. In the [documentation's minimal example](https://williamfalcon.github.io/pytorch-lightning/LightningModule/RequiredTrainerInterface/#minimal-example), the `validation_step` method returns a value for `val_loss` while the `validation_end` method returns a value for `avg_val_loss`. However, it seems like the `Trainer` only collects metrics from `validation_end` and not `validation_step`. This causes the default `EarlyStopping` callback to fail since it monitors the `val_loss` metric but only the `avg_val_loss` metric is being reported. This PR updates the `validation_end` method (in the docs example) to return `val_loss` so that it works out of the box with the `Trainer` defaults.  This conforms with the behavior in the `LightningTemplateModel`. 

In order to eliminate confusion, we should include more documentation on how the trainer collects metrics from `LightningModule` objects.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Always 😉 
