### PR TITLE
Fix percent_checks

### DIFF
--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -61,7 +61,6 @@ class TrainerDataLoadingMixin(ABC):
 
             self.num_training_batches = len(self.get_train_dataloader())
             self.num_training_batches = int(self.num_training_batches * self.train_percent_check)
-            self.num_training_batches = max(1, self.num_training_batches)
 
         # determine when to check validation
         # if int passed in, val checks that often
@@ -160,7 +159,6 @@ class TrainerDataLoadingMixin(ABC):
             len_sum = sum(len(dataloader) for dataloader in self.get_test_dataloaders())
             self.num_test_batches = len_sum
             self.num_test_batches = int(self.num_test_batches * self.test_percent_check)
-            self.num_test_batches = max(1, self.num_test_batches)
 
         on_ddp = self.use_ddp or self.use_ddp2
         if on_ddp and self.get_test_dataloaders() is not None:

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -48,15 +48,30 @@ class TrainerDataLoadingMixin(ABC):
         if EXIST_ITER_DATASET and isinstance(self.get_train_dataloader().dataset, IterableDataset):
             self.num_training_batches = float('inf')
         else:
+            if not 0. <= self.train_percent_check <= 1.:
+                raise ValueError(f"train_percent_check must lie in the range [0.0, 1.0], but got "
+                                 f"{self.train_percent_check:.3f}.")
+
             self.num_training_batches = len(self.get_train_dataloader())
             self.num_training_batches = int(self.num_training_batches * self.train_percent_check)
+            self.num_training_batches = max(1, self.num_training_batches)
 
         # determine when to check validation
         # if int passed in, val checks that often
         # otherwise, it checks in [0, 1.0] % range of a training epoch
         if isinstance(self.val_check_interval, int):
             self.val_check_batch = self.val_check_interval
+            if self.val_check_batch > self.num_training_batches:
+                raise ValueError(
+                    f"val_check_interval ({self.val_check_interval}) must be less than or equal to "
+                    f"the number of the training batches ({self.num_training_batches}). "
+                    f"If you want to disable validation set val_percent_check to 0.0 instead.")
         else:
+            if not 0. <= self.val_check_interval <= 1.:
+                raise ValueError(f"val_check_interval must lie in the range [0.0, 1.0], but got "
+                                 f"{self.val_check_interval:.3f}. If you want to disable "
+                                 f"validation set val_percent_check to 0.0 instead.")
+
             self.val_check_batch = int(self.num_training_batches * self.val_check_interval)
             self.val_check_batch = max(1, self.val_check_batch)
 
@@ -89,13 +104,18 @@ class TrainerDataLoadingMixin(ABC):
         :return:
         """
         self.get_val_dataloaders = model.val_dataloader
+        self.num_val_batches = 0
 
         # determine number of validation batches
         # val datasets could be none, 1 or 2+
         if self.get_val_dataloaders() is not None:
+            if not 0. <= self.val_percent_check <= 1.:
+                raise ValueError(f"val_percent_check must lie in the range [0.0, 1.0], but got "
+                                 f"{self.val_percent_check:.3f}. If you want to disable "
+                                 f"validation set it to 0.0.")
+
             self.num_val_batches = sum(len(dataloader) for dataloader in self.get_val_dataloaders())
             self.num_val_batches = int(self.num_val_batches * self.val_percent_check)
-            self.num_val_batches = max(1, self.num_val_batches)
 
         on_ddp = self.use_ddp or self.use_ddp2
         if on_ddp and self.get_val_dataloaders() is not None:
@@ -134,6 +154,10 @@ class TrainerDataLoadingMixin(ABC):
 
         # determine number of test batches
         if self.get_test_dataloaders() is not None:
+            if not 0. <= self.test_percent_check <= 1.:
+                raise ValueError(f"test_percent_check must lie in the range [0.0, 1.0], but got "
+                                 f"{self.test_percent_check:.3f}.")
+
             len_sum = sum(len(dataloader) for dataloader in self.get_test_dataloaders())
             self.num_test_batches = len_sum
             self.num_test_batches = int(self.num_test_batches * self.test_percent_check)
@@ -208,6 +232,10 @@ class TrainerDataLoadingMixin(ABC):
         self.val_percent_check = val_percent_check
         self.test_percent_check = test_percent_check
         if overfit_pct > 0:
+            if overfit_pct > 1:
+                raise ValueError(f"overfit_pct must be not greater than 1.0, but got "
+                                 f"{overfit_pct:.3f}.")
+
             self.train_percent_check = overfit_pct
             self.val_percent_check = overfit_pct
             self.test_percent_check = overfit_pct


### PR DESCRIPTION
This PR resolves #646 and resolves #631

In short:
- Now we can disable validation by setting `val_percent_check=0`.
- All percent_checks are checked to lie in the range [0.0, 1.0].
- Now `num_training_batches` and `num_test_batches` are always not less than 1.
- `val_check_interval` is checked to be in the range [0.0, 1.0] or to be not greater than `num_training_batches`.
