### PR TITLE
Temporary fix for PILLOW_VERSION issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ torchvision>=0.4.0
 pandas>=0.24  # lower version do not support py3.7
 test-tube>=0.7.5
 future>=0.17.1  # required for builtins in setup.py
+Pillow<7.0.0  # temporary fix until torchvision 0.4.3 is released


### PR DESCRIPTION
Fix for the error

    ImportError: cannot import name 'PILLOW_VERSION' from 'PIL'

This is fixed in torchvision master via https://github.com/pytorch/vision/pull/1501, but the fix is not in a release yet. It should roll out in torchvision==0.4.3 shortly. In the meantime, forcing Pillow<7.0.0 resolves the problem.

Once torchvision 0.4.3 is out, we should remove this line and require `torchvision>=0.4.3`